### PR TITLE
Add text input and preview flow

### DIFF
--- a/frontend/learnsynth/lib/constants.dart
+++ b/frontend/learnsynth/lib/constants.dart
@@ -3,6 +3,8 @@
 // prevents typos and makes refactoring easier.
 class Routes {
   static const String home = '/';
+  static const String textInput = '/text-input';
+  static const String preview = '/preview';
   static const String processing = '/processing';
   static const String analysis = '/analysis';
   static const String methodSelection = '/method-selection';

--- a/frontend/learnsynth/lib/main.dart
+++ b/frontend/learnsynth/lib/main.dart
@@ -11,6 +11,8 @@ import 'screens/memorization_screen.dart';
 import 'screens/contextual_association_screen.dart';
 import 'screens/interactive_evaluation_screen.dart';
 import 'screens/progress_screen.dart';
+import 'screens/text_input_screen.dart';
+import 'screens/preview_screen.dart';
 
 void main() {
   runApp(const StudyApp());
@@ -32,7 +34,15 @@ class StudyApp extends StatelessWidget {
         // in constants.dart. Also avoid using replacement navigation in
         // the routes table.
         Routes.home: (_) => const MainNavigation(),
-        Routes.processing: (_) => const ProcessingScreen(),
+        Routes.textInput: (_) => const TextInputScreen(),
+        Routes.preview: (context) {
+          final text = ModalRoute.of(context)?.settings.arguments as String? ?? '';
+          return PreviewScreen(text: text);
+        },
+        Routes.processing: (context) {
+          final text = ModalRoute.of(context)?.settings.arguments as String?;
+          return ProcessingScreen(text: text);
+        },
         Routes.analysis: (_) => const AnalysisScreen(),
         Routes.methodSelection: (_) => const MethodSelectionScreen(),
         Routes.deepUnderstanding: (_) => const DeepUnderstandingScreen(),

--- a/frontend/learnsynth/lib/screens/home_screen.dart
+++ b/frontend/learnsynth/lib/screens/home_screen.dart
@@ -3,8 +3,9 @@ import '../widgets/primary_button.dart';
 import '../constants.dart';
 
 /// Allows the user to add new content via multiple methods: pasting text,
-/// uploading a PDF, recording audio or uploading a video. Each action
-/// navigates to the processing screen using a named route.
+/// uploading a PDF, recording audio or uploading a video. Pasting text
+/// first opens a text input screen, while the other actions navigate
+/// directly to the processing screen using named routes.
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
@@ -21,7 +22,8 @@ class HomeScreen extends StatelessWidget {
               children: [
                 PrimaryButton(
                   label: 'Paste Text',
-                  onPressed: () => Navigator.pushNamed(context, Routes.processing),
+                  onPressed: () =>
+                      Navigator.pushNamed(context, Routes.textInput),
                 ),
                 const SizedBox(height: 16),
                 PrimaryButton(

--- a/frontend/learnsynth/lib/screens/preview_screen.dart
+++ b/frontend/learnsynth/lib/screens/preview_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/primary_button.dart';
+import '../constants.dart';
+
+/// Displays the provided text in a scrollable container and allows
+/// the user to start the analysis process.
+class PreviewScreen extends StatelessWidget {
+  final String text;
+  const PreviewScreen({super.key, required this.text});
+
+  void _startAnalysis(BuildContext context) {
+    Navigator.pushNamed(
+      context,
+      Routes.processing,
+      arguments: text,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Preview')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: Colors.black26,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    text,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyLarge
+                        ?.copyWith(color: Colors.white70),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              label: 'Start Analysis',
+              onPressed: () => _startAnalysis(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/frontend/learnsynth/lib/screens/processing_screen.dart
+++ b/frontend/learnsynth/lib/screens/processing_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../widgets/quote_card.dart';
-import '../widgets/primary_button.dart';
 import '../constants.dart';
 
 /// Shows a loading state while content is being processed. Once the
@@ -8,8 +7,28 @@ import '../constants.dart';
 /// screen. We use [Navigator.pushNamed] here rather than
 /// [Navigator.pushReplacementNamed] so that the user can navigate
 /// back if desired.
-class ProcessingScreen extends StatelessWidget {
-  const ProcessingScreen({super.key});
+class ProcessingScreen extends StatefulWidget {
+  final String? text;
+  const ProcessingScreen({super.key, this.text});
+
+  @override
+  State<ProcessingScreen> createState() => _ProcessingScreenState();
+}
+
+class _ProcessingScreenState extends State<ProcessingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 3), () {
+      if (mounted) {
+        Navigator.pushNamed(
+          context,
+          Routes.analysis,
+          arguments: widget.text,
+        );
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,15 +37,10 @@ class ProcessingScreen extends StatelessWidget {
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const CircularProgressIndicator(),
-            const SizedBox(height: 20),
-            const QuoteCard(quote: 'Learning never exhausts the mind.'),
-            const SizedBox(height: 20),
-            PrimaryButton(
-              label: 'View Analysis',
-              onPressed: () => Navigator.pushNamed(context, Routes.analysis),
-            ),
+          children: const [
+            CircularProgressIndicator(),
+            SizedBox(height: 20),
+            QuoteCard(quote: 'Learning never exhausts the mind.'),
           ],
         ),
       ),

--- a/frontend/learnsynth/lib/screens/text_input_screen.dart
+++ b/frontend/learnsynth/lib/screens/text_input_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/primary_button.dart';
+import '../constants.dart';
+
+/// Provides a multiline text field for users to paste or type text.
+/// Upon continuing the text is passed to the preview screen.
+class TextInputScreen extends StatefulWidget {
+  const TextInputScreen({super.key});
+
+  @override
+  State<TextInputScreen> createState() => _TextInputScreenState();
+}
+
+class _TextInputScreenState extends State<TextInputScreen> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _continue() {
+    Navigator.pushNamed(
+      context,
+      Routes.preview,
+      arguments: _controller.text,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Text')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  hintText: 'Enter or paste text here',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            PrimaryButton(label: 'Continue', onPressed: _continue),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add new `TextInputScreen` and `PreviewScreen`
- pass text through the flow and auto-forward from `ProcessingScreen`
- register routes for the new screens
- update home screen's Paste Text button

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873f8736288329833424526e54703a