### PR TITLE
Enhance study app upload flow

### DIFF
--- a/frontend/learnsynth/lib/screens/home_screen.dart
+++ b/frontend/learnsynth/lib/screens/home_screen.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
-import '../widgets/primary_button.dart';
+import 'package:file_picker/file_picker.dart';
+import '../widgets/method_card.dart';
 import '../constants.dart';
 
+// Updated to use MethodCard widgets with file_picker for a more
+// consistent, card-based design similar to the method selection screen.
+
 /// Allows the user to add new content via multiple methods: pasting text,
-/// uploading a PDF, recording audio or uploading a video. Pasting text
-/// first opens a text input screen, while the other actions navigate
-/// directly to the processing screen using named routes.
+/// uploading a PDF, recording audio or uploading a video. Each option now
+/// opens an input picker before showing the processing screen.
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
@@ -15,34 +18,60 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Add Content')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: Center(
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                PrimaryButton(
-                  label: 'Paste Text',
-                  onPressed: () =>
-                      Navigator.pushNamed(context, Routes.textInput),
-                ),
-                const SizedBox(height: 16),
-                PrimaryButton(
-                  label: 'Upload PDF',
-                  onPressed: () => Navigator.pushNamed(context, Routes.processing),
-                ),
-                const SizedBox(height: 16),
-                PrimaryButton(
-                  label: 'Record Audio',
-                  onPressed: () => Navigator.pushNamed(context, Routes.processing),
-                ),
-                const SizedBox(height: 16),
-                PrimaryButton(
-                  label: 'Upload Video',
-                  onPressed: () => Navigator.pushNamed(context, Routes.processing),
-                ),
-              ],
+        child: ListView(
+          children: [
+            MethodCard(
+              icon: Icons.text_fields,
+              title: 'Paste Text',
+              description: 'Type or paste plain text.',
+              onTap: () => Navigator.pushNamed(context, Routes.textInput),
             ),
-          ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.picture_as_pdf,
+              title: 'Upload PDF',
+              description: 'Pick a PDF document to analyse.',
+              onTap: () async {
+                final result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ['pdf']);
+                if (result != null && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Selected ${result.files.single.name}')),
+                  );
+                  Navigator.pushNamed(context, Routes.processing);
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.mic,
+              title: 'Record Audio',
+              description: 'Select an audio file.',
+              onTap: () async {
+                final result = await FilePicker.platform.pickFiles(type: FileType.audio);
+                if (result != null && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Selected ${result.files.single.name}')),
+                  );
+                  Navigator.pushNamed(context, Routes.processing);
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.video_file,
+              title: 'Upload Video',
+              description: 'Select a video for transcription.',
+              onTap: () async {
+                final result = await FilePicker.platform.pickFiles(type: FileType.video);
+                if (result != null && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Selected ${result.files.single.name}')),
+                  );
+                  Navigator.pushNamed(context, Routes.processing);
+                }
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/frontend/learnsynth/lib/screens/processing_screen.dart
+++ b/frontend/learnsynth/lib/screens/processing_screen.dart
@@ -19,7 +19,8 @@ class _ProcessingScreenState extends State<ProcessingScreen> {
   @override
   void initState() {
     super.initState();
-    Future.delayed(const Duration(seconds: 3), () {
+    // Shortened delay to keep the demo snappy.
+    Future.delayed(const Duration(seconds: 2), () {
       if (mounted) {
         Navigator.pushNamed(
           context,

--- a/frontend/learnsynth/lib/screens/progress_screen.dart
+++ b/frontend/learnsynth/lib/screens/progress_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import '../widgets/progress_summary_card.dart';
-import '../widgets/primary_button.dart';
+import '../widgets/quote_card.dart';
 import '../constants.dart';
 
-/// Displays summary statistics for the user’s progress. The "Back to
-/// Home" button now uses [Navigator.pushNamedAndRemoveUntil] to clear
-/// the navigation stack and return to the home screen cleanly.
+/// Displays summary statistics for the user’s progress. Navigation back
+/// to the home page is provided by the bottom navigation bar, so we
+/// simply show a motivational quote instead of a button.
 class ProgressScreen extends StatelessWidget {
   const ProgressScreen({super.key});
 
@@ -23,14 +23,9 @@ class ProgressScreen extends StatelessWidget {
             const SizedBox(height: 16),
             const ProgressSummaryCard(title: 'Methods Used', value: '3'),
             const SizedBox(height: 16),
-            PrimaryButton(
-              label: 'Back to Home',
-              onPressed: () => Navigator.pushNamedAndRemoveUntil(
-                context,
-                Routes.home,
-                (route) => false,
-              ),
-            ),
+            // Navigation back to home is handled by the bottom nav bar.
+            // We show a motivational quote instead of a button.
+            const QuoteCard(quote: 'Keep up the great work!'),
           ],
         ),
       ),

--- a/frontend/learnsynth/lib/screens/text_input_screen.dart
+++ b/frontend/learnsynth/lib/screens/text_input_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 
 import '../widgets/primary_button.dart';
+import '../theme/app_theme.dart';
+
+// Styled text field is wrapped in a Card for better visual hierarchy.
 import '../constants.dart';
 
 /// Provides a multiline text field for users to paste or type text.
-/// Upon continuing the text is passed to the preview screen.
+/// After continuing a short loading screen is shown before
+/// navigating to the analysis stage.
 class TextInputScreen extends StatefulWidget {
   const TextInputScreen({super.key});
 
@@ -21,10 +25,12 @@ class _TextInputScreenState extends State<TextInputScreen> {
     super.dispose();
   }
 
+  // After tapping Continue we show the processing screen for a brief
+  // moment before navigating to analysis.
   void _continue() {
     Navigator.pushNamed(
       context,
-      Routes.preview,
+      Routes.processing,
       arguments: _controller.text,
     );
   }
@@ -39,12 +45,22 @@ class _TextInputScreenState extends State<TextInputScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              child: TextField(
-                controller: _controller,
-                maxLines: null,
-                decoration: const InputDecoration(
-                  hintText: 'Enter or paste text here',
-                  border: OutlineInputBorder(),
+              child: Card(
+                color: AppTheme.accentGray,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: TextField(
+                    controller: _controller,
+                    maxLines: null,
+                    style: const TextStyle(color: Colors.white),
+                    decoration: const InputDecoration(
+                      hintText: 'Enter or paste text here',
+                      border: InputBorder.none,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # Allows picking local files for the mocked upload flow.
+  file_picker: ^6.1.1
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- style Add Content screen with `MethodCard` and file picker
- style text input with card and send text to processing
- shorten processing delay
- update progress screen layout
- add `file_picker` dependency

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68874289edd88329906b25b7c0fc431b