### PR TITLE
Improve navigation and state management

### DIFF
--- a/frontend/learnsynth/lib/constants.dart
+++ b/frontend/learnsynth/lib/constants.dart
@@ -5,7 +5,7 @@ class Routes {
   static const String home = '/';
   static const String textInput = '/text-input';
   static const String preview = '/preview';
-  static const String processing = '/processing';
+  static const String loading = '/loading';
   static const String analysis = '/analysis';
   static const String methodSelection = '/method-selection';
   static const String deepUnderstanding = '/deep-understanding';
@@ -13,4 +13,9 @@ class Routes {
   static const String contextualAssociation = '/contextual-association';
   static const String interactiveEvaluation = '/interactive-evaluation';
   static const String progress = '/progress';
+  static const String addContent = '/add-content';
+  static const String pdfPicker = '/pdf-picker';
+  static const String audioRecorder = '/audio-recorder';
+  static const String videoPicker = '/video-picker';
+  static const String projects = '/projects';
 }

--- a/frontend/learnsynth/lib/content_provider.dart
+++ b/frontend/learnsynth/lib/content_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+/// Stores the content added by the user so it can be accessed across screens.
+class ContentProvider extends ChangeNotifier {
+  String? text;
+  String? filePath;
+
+  void setText(String value) {
+    text = value;
+    filePath = null;
+    notifyListeners();
+  }
+
+  void setPdfPath(String path) {
+    filePath = path;
+    text = null;
+    notifyListeners();
+  }
+
+  void setAudioPath(String path) {
+    filePath = path;
+    text = null;
+    notifyListeners();
+  }
+
+  void setVideoPath(String path) {
+    filePath = path;
+    text = null;
+    notifyListeners();
+  }
+}

--- a/frontend/learnsynth/lib/main.dart
+++ b/frontend/learnsynth/lib/main.dart
@@ -3,8 +3,13 @@ import 'package:flutter/material.dart';
 import 'constants.dart';
 import 'theme/app_theme.dart';
 import 'screens/home_screen.dart';
-import 'screens/processing_screen.dart';
+import 'screens/add_content_screen.dart';
+import 'screens/loading_screen.dart';
 import 'screens/analysis_screen.dart';
+import 'screens/pdf_picker_screen.dart';
+import 'screens/audio_recorder_screen.dart';
+import 'screens/video_picker_screen.dart';
+import 'screens/projects_screen.dart';
 import 'screens/method_selection_screen.dart';
 import 'screens/deep_understanding_screen.dart';
 import 'screens/memorization_screen.dart';
@@ -13,9 +18,16 @@ import 'screens/interactive_evaluation_screen.dart';
 import 'screens/progress_screen.dart';
 import 'screens/text_input_screen.dart';
 import 'screens/preview_screen.dart';
+import 'package:provider/provider.dart';
+import 'content_provider.dart';
 
 void main() {
-  runApp(const StudyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => ContentProvider(),
+      child: const StudyApp(),
+    ),
+  );
 }
 
 class StudyApp extends StatelessWidget {
@@ -34,14 +46,19 @@ class StudyApp extends StatelessWidget {
         // in constants.dart. Also avoid using replacement navigation in
         // the routes table.
         Routes.home: (_) => const MainNavigation(),
+        Routes.addContent: (_) => const AddContentScreen(),
         Routes.textInput: (_) => const TextInputScreen(),
+        Routes.pdfPicker: (_) => const PdfPickerScreen(),
+        Routes.audioRecorder: (_) => const AudioRecorderScreen(),
+        Routes.videoPicker: (_) => const VideoPickerScreen(),
+        Routes.projects: (_) => const ProjectsScreen(),
         Routes.preview: (context) {
           final text = ModalRoute.of(context)?.settings.arguments as String? ?? '';
           return PreviewScreen(text: text);
         },
-        Routes.processing: (context) {
+        Routes.loading: (context) {
           final text = ModalRoute.of(context)?.settings.arguments as String?;
-          return ProcessingScreen(text: text);
+          return LoadingScreen(text: text);
         },
         Routes.analysis: (_) => const AnalysisScreen(),
         Routes.methodSelection: (_) => const MethodSelectionScreen(),
@@ -88,7 +105,7 @@ class _MainNavigationState extends State<MainNavigation> {
         unselectedItemColor: Colors.white54,
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-          BottomNavigationBarItem(icon: Icon(Icons.folder), label: 'Projects'),
+          BottomNavigationBarItem(icon: Icon(Icons.folder), label: 'Progress'),
           BottomNavigationBarItem(icon: Icon(Icons.bookmark), label: 'Library'),
         ],
       ),

--- a/frontend/learnsynth/lib/screens/add_content_screen.dart
+++ b/frontend/learnsynth/lib/screens/add_content_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import '../widgets/method_card.dart';
+import '../constants.dart';
+import '../content_provider.dart';
+
+/// Lists the available ways to add new study content.
+class AddContentScreen extends StatelessWidget {
+  const AddContentScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Provider.of<ContentProvider>(context, listen: false);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Content')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: ListView(
+          children: [
+            MethodCard(
+              icon: Icons.text_fields,
+              title: 'Paste Text',
+              description: 'Type or paste plain text.',
+              onTap: () => Navigator.pushNamed(context, Routes.textInput),
+            ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.picture_as_pdf,
+              title: 'Upload PDF',
+              description: 'Pick a PDF document to analyse.',
+              onTap: () async {
+                final result = await FilePicker.platform.pickFiles(
+                  type: FileType.custom,
+                  allowedExtensions: ['pdf'],
+                );
+                if (result != null && result.files.single.path != null && context.mounted) {
+                  content.setPdfPath(result.files.single.path!);
+                  Navigator.pushNamed(context, Routes.loading);
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.mic,
+              title: 'Record Audio',
+              description: 'Record using the microphone.',
+              onTap: () => Navigator.pushNamed(context, Routes.audioRecorder),
+            ),
+            const SizedBox(height: 16),
+            MethodCard(
+              icon: Icons.video_file,
+              title: 'Upload Video',
+              description: 'Select a video for transcription.',
+              onTap: () async {
+                final result = await FilePicker.platform.pickFiles(type: FileType.video);
+                if (result != null && result.files.single.path != null && context.mounted) {
+                  content.setVideoPath(result.files.single.path!);
+                  Navigator.pushNamed(context, Routes.loading);
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/learnsynth/lib/screens/analysis_screen.dart
+++ b/frontend/learnsynth/lib/screens/analysis_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
+import '../content_provider.dart';
 
 /// Presents the processed text to the user and allows them to choose
 /// their preferred study method. The text is scrollable and uses
@@ -10,7 +12,9 @@ class AnalysisScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String processedText = List.filled(10, 'Processed text goes here...\n').join();
+    final provider = context.watch<ContentProvider>();
+    final String processedText =
+        provider.text ?? 'Processed text goes here...';
     return Scaffold(
       appBar: AppBar(title: const Text('Analysis')),
       body: Padding(

--- a/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:record/record.dart';
+import '../widgets/primary_button.dart';
+import '../constants.dart';
+import '../content_provider.dart';
+
+/// Simple audio recorder using the `record` package.
+class AudioRecorderScreen extends StatefulWidget {
+  const AudioRecorderScreen({super.key});
+
+  @override
+  State<AudioRecorderScreen> createState() => _AudioRecorderScreenState();
+}
+
+class _AudioRecorderScreenState extends State<AudioRecorderScreen> {
+  final Record _record = Record();
+  bool _isRecording = false;
+
+  Future<void> _toggleRecording() async {
+    if (_isRecording) {
+      final path = await _record.stop();
+      if (path != null && context.mounted) {
+        Provider.of<ContentProvider>(context, listen: false).setAudioPath(path);
+        Navigator.pushNamed(context, Routes.loading);
+      }
+    } else {
+      await _record.start();
+    }
+    setState(() => _isRecording = !_isRecording);
+  }
+
+  @override
+  void dispose() {
+    _record.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Record Audio')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Center(
+          child: PrimaryButton(
+            label: _isRecording ? 'Stop Recording' : 'Start Recording',
+            onPressed: _toggleRecording,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/learnsynth/lib/screens/home_screen.dart
+++ b/frontend/learnsynth/lib/screens/home_screen.dart
@@ -1,75 +1,33 @@
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
-import '../widgets/method_card.dart';
+import '../widgets/primary_button.dart';
 import '../constants.dart';
 
-// Updated to use MethodCard widgets with file_picker for a more
-// consistent, card-based design similar to the method selection screen.
-
-/// Allows the user to add new content via multiple methods: pasting text,
-/// uploading a PDF, recording audio or uploading a video. Each option now
-/// opens an input picker before showing the processing screen.
+/// Initial landing page with quick navigation buttons.
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Content')),
+      appBar: AppBar(title: const Text('Home')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: ListView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            MethodCard(
-              icon: Icons.text_fields,
-              title: 'Paste Text',
-              description: 'Type or paste plain text.',
-              onTap: () => Navigator.pushNamed(context, Routes.textInput),
+            PrimaryButton(
+              label: 'Add Content',
+              onPressed: () => Navigator.pushNamed(context, Routes.addContent),
             ),
             const SizedBox(height: 16),
-            MethodCard(
-              icon: Icons.picture_as_pdf,
-              title: 'Upload PDF',
-              description: 'Pick a PDF document to analyse.',
-              onTap: () async {
-                final result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ['pdf']);
-                if (result != null && context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Selected ${result.files.single.name}')),
-                  );
-                  Navigator.pushNamed(context, Routes.processing);
-                }
-              },
+            PrimaryButton(
+              label: 'Projects',
+              onPressed: () => Navigator.pushNamed(context, Routes.projects),
             ),
             const SizedBox(height: 16),
-            MethodCard(
-              icon: Icons.mic,
-              title: 'Record Audio',
-              description: 'Select an audio file.',
-              onTap: () async {
-                final result = await FilePicker.platform.pickFiles(type: FileType.audio);
-                if (result != null && context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Selected ${result.files.single.name}')),
-                  );
-                  Navigator.pushNamed(context, Routes.processing);
-                }
-              },
-            ),
-            const SizedBox(height: 16),
-            MethodCard(
-              icon: Icons.video_file,
-              title: 'Upload Video',
-              description: 'Select a video for transcription.',
-              onTap: () async {
-                final result = await FilePicker.platform.pickFiles(type: FileType.video);
-                if (result != null && context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Selected ${result.files.single.name}')),
-                  );
-                  Navigator.pushNamed(context, Routes.processing);
-                }
-              },
+            PrimaryButton(
+              label: 'Library',
+              onPressed: () {},
             ),
           ],
         ),

--- a/frontend/learnsynth/lib/screens/loading_screen.dart
+++ b/frontend/learnsynth/lib/screens/loading_screen.dart
@@ -7,20 +7,19 @@ import '../constants.dart';
 /// screen. We use [Navigator.pushNamed] here rather than
 /// [Navigator.pushReplacementNamed] so that the user can navigate
 /// back if desired.
-class ProcessingScreen extends StatefulWidget {
+class LoadingScreen extends StatefulWidget {
   final String? text;
-  const ProcessingScreen({super.key, this.text});
+  const LoadingScreen({super.key, this.text});
 
   @override
-  State<ProcessingScreen> createState() => _ProcessingScreenState();
+  State<LoadingScreen> createState() => _LoadingScreenState();
 }
 
-class _ProcessingScreenState extends State<ProcessingScreen> {
+class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    // Shortened delay to keep the demo snappy.
-    Future.delayed(const Duration(seconds: 2), () {
+    Future.delayed(const Duration(seconds: 3), () {
       if (mounted) {
         Navigator.pushNamed(
           context,
@@ -34,7 +33,7 @@ class _ProcessingScreenState extends State<ProcessingScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Processing')),
+      appBar: AppBar(title: const Text('Loading')),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/learnsynth/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/pdf_picker_screen.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import '../widgets/primary_button.dart';
+import '../constants.dart';
+import '../content_provider.dart';
+
+/// Allows the user to pick a PDF file and reads its text.
+class PdfPickerScreen extends StatelessWidget {
+  const PdfPickerScreen({super.key});
+
+  Future<void> _pickPdf(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf'],
+    );
+    if (result != null && result.files.single.path != null && context.mounted) {
+      final path = result.files.single.path!;
+      String text = 'PDF selected: ${result.files.single.name}';
+      try {
+        text = await File(path).readAsString();
+      } catch (_) {}
+      Provider.of<ContentProvider>(context, listen: false).setText(text);
+      Navigator.pushNamed(context, Routes.loading);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload PDF')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Center(
+          child: PrimaryButton(
+            label: 'Choose PDF',
+            onPressed: () => _pickPdf(context),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/learnsynth/lib/screens/preview_screen.dart
+++ b/frontend/learnsynth/lib/screens/preview_screen.dart
@@ -10,11 +10,7 @@ class PreviewScreen extends StatelessWidget {
   const PreviewScreen({super.key, required this.text});
 
   void _startAnalysis(BuildContext context) {
-    Navigator.pushNamed(
-      context,
-      Routes.processing,
-      arguments: text,
-    );
+    Navigator.pushNamed(context, Routes.loading, arguments: text);
   }
 
   @override

--- a/frontend/learnsynth/lib/screens/projects_screen.dart
+++ b/frontend/learnsynth/lib/screens/projects_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder screen for future projects feature.
+class ProjectsScreen extends StatelessWidget {
+  const ProjectsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Projects coming soon', style: TextStyle(color: Colors.white70)),
+      ),
+    );
+  }
+}

--- a/frontend/learnsynth/lib/screens/text_input_screen.dart
+++ b/frontend/learnsynth/lib/screens/text_input_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
 import '../theme/app_theme.dart';
-
-// Styled text field is wrapped in a Card for better visual hierarchy.
 import '../constants.dart';
+import '../content_provider.dart';
 
 /// Provides a multiline text field for users to paste or type text.
 /// After continuing a short loading screen is shown before
@@ -25,14 +25,12 @@ class _TextInputScreenState extends State<TextInputScreen> {
     super.dispose();
   }
 
-  // After tapping Continue we show the processing screen for a brief
-  // moment before navigating to analysis.
+  // After tapping Continue we store the text and show a loading screen
+  // before navigating to analysis.
   void _continue() {
-    Navigator.pushNamed(
-      context,
-      Routes.processing,
-      arguments: _controller.text,
-    );
+    Provider.of<ContentProvider>(context, listen: false)
+        .setText(_controller.text);
+    Navigator.pushNamed(context, Routes.loading);
   }
 
   @override

--- a/frontend/learnsynth/lib/screens/video_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/video_picker_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import '../widgets/primary_button.dart';
+import '../constants.dart';
+import '../content_provider.dart';
+
+/// Picks a video file from the device.
+class VideoPickerScreen extends StatelessWidget {
+  const VideoPickerScreen({super.key});
+
+  Future<void> _pickVideo(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(type: FileType.video);
+    if (result != null && result.files.single.path != null && context.mounted) {
+      Provider.of<ContentProvider>(context, listen: false)
+          .setVideoPath(result.files.single.path!);
+      Navigator.pushNamed(context, Routes.loading);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload Video')),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Center(
+          child: PrimaryButton(
+            label: 'Choose Video',
+            onPressed: () => _pickVideo(context),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
 
   # Allows picking local files for the mocked upload flow.
   file_picker: ^6.1.1
+  provider: ^6.0.5
+  record: ^5.0.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- create `ContentProvider` and wrap app with provider
- add `AddContentScreen` and dedicated pickers
- rename `ProcessingScreen` to `LoadingScreen` with 3s delay
- replace home screen with buttons to new content screen
- fix bottom navigation label and routing
- wire up provider in input and analysis screens
- add `provider` and `record` packages

## Testing
- `git status --short`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887450e2b9c83299f0613de6ba83a41