### PR TITLE
Fix record path parameter usage

### DIFF
--- a/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
@@ -37,17 +37,15 @@ class _AudioRecorderScreenState extends State<AudioRecorderScreen> {
     } else {
       await requestMicPermission();
 
-      final dir = await getApplicationDocumentsDirectory();
+      final dir = await getTemporaryDirectory();
       final filePath =
           '${dir.path}/recording_${DateTime.now().millisecondsSinceEpoch}.m4a';
 
       await _record.start(
-        const RecordConfig(
-          encoder: AudioEncoder.aacLc,
-          bitRate: 128000,
-          sampleRate: 44100,
-        ),
         path: filePath,
+        encoder: AudioEncoder.aac,
+        bitRate: 128000,
+        samplingRate: 44100,
       );
     }
 


### PR DESCRIPTION
## Summary
- use `getTemporaryDirectory()` for new recording temp files
- start recording with `path`, encoder, bitrate and sampling rate arguments

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874e01a8ec83298de2bd033f4bd0c2