### PR TITLE
Use file picker for audio files

### DIFF
--- a/frontend/learnsynth/lib/screens/add_content_screen.dart
+++ b/frontend/learnsynth/lib/screens/add_content_screen.dart
@@ -44,8 +44,8 @@ class AddContentScreen extends StatelessWidget {
             const SizedBox(height: 16),
             MethodCard(
               icon: Icons.mic,
-              title: 'Record Audio',
-              description: 'Record using the microphone.',
+              title: 'Upload Audio',
+              description: 'Pick an audio file for transcription.',
               onTap: () => Navigator.pushNamed(context, Routes.audioRecorder),
             ),
             const SizedBox(height: 16),

--- a/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_recorder_screen.dart
@@ -1,65 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:record/record.dart';
+import 'package:file_picker/file_picker.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
-import 'package:path_provider/path_provider.dart';
 
-/// Simple audio recorder using the `record` package.
-class AudioRecorderScreen extends StatefulWidget {
+/// Allows the user to pick an existing audio file.
+class AudioRecorderScreen extends StatelessWidget {
   const AudioRecorderScreen({super.key});
 
-  @override
-  State<AudioRecorderScreen> createState() => _AudioRecorderScreenState();
-}
-
-class _AudioRecorderScreenState extends State<AudioRecorderScreen> {
-  final _record = AudioRecorder();
-  bool _isRecording = false;
-
-  Future<void> _toggleRecording() async {
-    if (_isRecording) {
-      final path = await _record.stop();
-
-      if (path != null && context.mounted) {
-        Provider.of<ContentProvider>(context, listen: false).setAudioPath(path);
-        Navigator.pushNamed(context, Routes.loading);
-      }
-    } else {
-      final directory = await getApplicationDocumentsDirectory();
-      final filePath =
-          '${directory.path}/recording_${DateTime.now().millisecondsSinceEpoch}.m4a';
-
-      await _record.start(
-        const RecordConfig(
-          encoder: AudioEncoder.aacLc, // o .opus, .wav
-          bitRate: 128000,
-          sampleRate: 44100,
-        ),
-        path: filePath,
-      );
+  Future<void> _pickAudio(BuildContext context) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['mp3', 'wav', 'm4a', 'aac', 'opus'],
+    );
+    if (result != null && result.files.single.path != null && context.mounted) {
+      Provider.of<ContentProvider>(context, listen: false)
+          .setAudioPath(result.files.single.path!);
+      Navigator.pushNamed(context, Routes.loading);
     }
-
-    setState(() => _isRecording = !_isRecording);
-  }
-
-  @override
-  void dispose() {
-    _record.dispose();
-    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Record Audio')),
+      appBar: AppBar(title: const Text('Upload Audio')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Center(
           child: PrimaryButton(
-            label: _isRecording ? 'Stop Recording' : 'Start Recording',
-            onPressed: _toggleRecording,
+            label: 'Upload Audio',
+            onPressed: () => _pickAudio(context),
           ),
         ),
       ),

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
     sdk: flutter
 
   # Allows picking local files for the mocked upload flow.
-  record: ^5.0.0
   file_picker: ^6.2.1
   path_provider: ^2.1.1
   provider: ^6.1.1


### PR DESCRIPTION
## Summary
- swap audio recording for audio file selection
- rename Add Content screen option to "Upload Audio"
- remove `record` dependency

## Testing
- `dart format lib/screens/audio_recorder_screen.dart lib/screens/add_content_screen.dart pubspec.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887512bc860832984abcc89865d947b