### PR TITLE
Fix duplicate Library button

### DIFF
--- a/frontend/learnsynth/lib/screens/home_screen.dart
+++ b/frontend/learnsynth/lib/screens/home_screen.dart
@@ -21,13 +21,8 @@ class HomeScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             PrimaryButton(
-              label: 'Projects',
-              onPressed: () => Navigator.pushNamed(context, Routes.projects),
-            ),
-            const SizedBox(height: 16),
-            PrimaryButton(
               label: 'Library',
-              onPressed: () {},
+              onPressed: () => Navigator.pushNamed(context, Routes.projects),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- remove extra Library button on Home screen
- rename the Projects button to Library to keep navigation to `/projects`

## Testing
- `dart format -o none --set-exit-if-changed lib/screens/home_screen.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688800dc15f08329a9d064192bc36780