### PR TITLE
Launch with AddContentScreen

### DIFF
--- a/frontend/learnsynth/lib/main.dart
+++ b/frontend/learnsynth/lib/main.dart
@@ -39,7 +39,7 @@ class StudyApp extends StatelessWidget {
       title: 'Interactive Learning App',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.darkTheme,
-      initialRoute: Routes.home,
+      initialRoute: Routes.addContent,
       routes: {
         // Map each named route to its corresponding screen. Note that
         // it’s important to keep this list in sync with the definitions


### PR DESCRIPTION
## Summary
- start the Flutter app on AddContentScreen instead of HomeScreen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880a4c58588329b7a50ad3ef3d892a