### PR TITLE
Extend study screens with provider data

### DIFF
--- a/frontend/learnsynth/lib/screens/contextual_association_screen.dart
+++ b/frontend/learnsynth/lib/screens/contextual_association_screen.dart
@@ -67,7 +67,21 @@ class _ContextualAssociationScreenState
             : Column(
                 children: [
                   if (exercises.isNotEmpty)
-                    Text(exercises.first.toString())
+                    Expanded(
+                      child: ListView.separated(
+                        itemCount: exercises.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 16),
+                        itemBuilder: (context, index) {
+                          final ex = exercises[index];
+                          return Card(
+                            child: Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Text(ex.toString()),
+                            ),
+                          );
+                        },
+                      ),
+                    )
                   else
                     const Text('No exercises generated'),
                   const SizedBox(height: 16),

--- a/frontend/learnsynth/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learnsynth/lib/screens/interactive_evaluation_screen.dart
@@ -68,12 +68,28 @@ class _InteractiveEvaluationScreenState
             : Column(
                 children: [
                   if (exercises.isNotEmpty)
-                    QuizQuestionCard(
-                      question: exercises.first['question'] ?? '',
-                      choices:
-                          List<String>.from(exercises.first['choices'] ?? []),
-                      correctIndex:
-                          exercises.first['correctIndex'] as int? ?? 0,
+                    Expanded(
+                      child: ListView.separated(
+                        itemCount: exercises.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 16),
+                        itemBuilder: (context, index) {
+                          final ex = exercises[index];
+                          if (ex.containsKey('choices')) {
+                            return QuizQuestionCard(
+                              question: ex['question'] ?? '',
+                              choices:
+                                  List<String>.from(ex['choices'] ?? const []),
+                              correctIndex: ex['correctIndex'] as int? ?? 0,
+                            );
+                          }
+                          return Card(
+                            child: Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Text(ex['question']?.toString() ?? ex.toString()),
+                            ),
+                          );
+                        },
+                      ),
                     )
                   else
                     const Text('No questions generated'),


### PR DESCRIPTION
## Summary
- display all exercises from the provider in Contextual Association
- show every generated quiz question in Interactive Evaluation

## Testing
- `python3 -m pip install -r backend/requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6889da7662ec83298b1671e2ee593c4d