### PR TITLE
Fix study screens and backend modes

### DIFF
--- a/frontend/learnsynth/lib/content_provider.dart
+++ b/frontend/learnsynth/lib/content_provider.dart
@@ -17,7 +17,8 @@ class ContentProvider extends ChangeNotifier {
   List<String> topics = [];
   List<Map<String, String>> flashcards = [];
   Map<String, dynamic>? conceptMap;
-  List<Map<String, dynamic>> exercises = [];
+  List<Map<String, dynamic>> contextualExercises = [];
+  List<Map<String, dynamic>> evaluationQuestions = [];
   final List<ContentItem> _saved = [];
 
   /// List of all content pieces added by the user.
@@ -81,8 +82,13 @@ class ContentProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setExercises(List<Map<String, dynamic>> list) {
-    exercises = list;
+  void setContextualExercises(List<Map<String, dynamic>> list) {
+    contextualExercises = list;
+    notifyListeners();
+  }
+
+  void setEvaluationQuestions(List<Map<String, dynamic>> list) {
+    evaluationQuestions = list;
     notifyListeners();
   }
 

--- a/frontend/learnsynth/lib/screens/contextual_association_screen.dart
+++ b/frontend/learnsynth/lib/screens/contextual_association_screen.dart
@@ -29,19 +29,23 @@ class _ContextualAssociationScreenState
 
   Future<void> _fetch() async {
     final provider = Provider.of<ContentProvider>(context, listen: false);
+    if (provider.contextualExercises.isNotEmpty) {
+      setState(() => _loading = false);
+      return;
+    }
     try {
       final url = Uri.parse('http://10.0.2.2:8000/study-mode');
       final response = await http.post(
         url,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'text': provider.text, 'mode': 'exercises'}),
+        body: jsonEncode({'text': provider.text, 'mode': 'contextual_association'}),
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final ex = (data['exercises'] as List? ?? [])
+        final ex = (data['contextualExercises'] as List? ?? data['exercises'] as List? ?? [])
             .map<Map<String, dynamic>>( (e) => Map<String, dynamic>.from(e as Map))
             .toList();
-        provider.setExercises(ex);
+        provider.setContextualExercises(ex);
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Failed to load exercises')),
@@ -57,7 +61,7 @@ class _ContextualAssociationScreenState
 
   @override
   Widget build(BuildContext context) {
-    final exercises = context.watch<ContentProvider>().exercises;
+    final exercises = context.watch<ContentProvider>().contextualExercises;
     return Scaffold(
       appBar: AppBar(title: const Text('Contextual Association')),
       body: Padding(
@@ -76,7 +80,7 @@ class _ContextualAssociationScreenState
                           return Card(
                             child: Padding(
                               padding: const EdgeInsets.all(16.0),
-                              child: Text(ex.toString()),
+                              child: Text(ex['question']?.toString() ?? ex['prompt']?.toString() ?? ex.toString()),
                             ),
                           );
                         },

--- a/frontend/learnsynth/lib/screens/memorization_screen.dart
+++ b/frontend/learnsynth/lib/screens/memorization_screen.dart
@@ -28,16 +28,20 @@ class _MemorizationScreenState extends State<MemorizationScreen> {
 
   Future<void> _fetch() async {
     final provider = Provider.of<ContentProvider>(context, listen: false);
+    if (provider.flashcards.isNotEmpty) {
+      setState(() => _loading = false);
+      return;
+    }
     try {
       final url = Uri.parse('http://10.0.2.2:8000/study-mode');
       final response = await http.post(
         url,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'text': provider.text, 'mode': 'flashcards'}),
+        body: jsonEncode({'text': provider.text, 'mode': 'memorization'}),
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final cards = (data['cards'] as List? ?? [])
+        final cards = (data['flashcards'] as List? ?? data['cards'] as List? ?? [])
             .map<Map<String, String>>(
                 (e) => Map<String, String>.from(e as Map))
             .toList();


### PR DESCRIPTION
## Summary
- support new study modes in backend `/study-mode`
- store contextual and evaluation data in ContentProvider
- memoize study results to avoid repeated requests
- parse and display concept map links cleanly
- handle new modes on all study screens

## Testing
- `python -m py_compile backend/main.py backend/app/services/*.py backend/app/models.py`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889dca3139483298b490e9f7d495e9f