### PR TITLE
Handle raw text and better analysis errors

### DIFF
--- a/frontend/learnsynth/lib/content_provider.dart
+++ b/frontend/learnsynth/lib/content_provider.dart
@@ -11,7 +11,12 @@ class ContentItem {
 
 /// Stores the content added by the user so it can be accessed across screens.
 class ContentProvider extends ChangeNotifier {
+  /// Cleaned or processed text used throughout the study flow.
   String? text;
+
+  /// Raw text extracted from uploaded files before any processing.
+  String? rawText;
+
   String? filePath;
   String? summary;
   List<String> topics = [];
@@ -26,6 +31,7 @@ class ContentProvider extends ChangeNotifier {
 
   void setText(String value) {
     text = value;
+    rawText = value;
     filePath = null;
     _saved.add(ContentItem(text: value));
     notifyListeners();
@@ -53,7 +59,9 @@ class ContentProvider extends ChangeNotifier {
   }
 
   /// Store both [path] and [text] for the same content item.
+  /// The raw text is kept in [rawText] so it can be processed later.
   void setFileContent({required String path, required String text}) {
+    rawText = text;
     this.text = text;
     filePath = path;
     final index = _saved.lastIndexWhere((item) => item.filePath == path);

--- a/frontend/learnsynth/lib/screens/loading_screen.dart
+++ b/frontend/learnsynth/lib/screens/loading_screen.dart
@@ -32,7 +32,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       final response = await http.post(
         url,
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'text': provider.text}),
+        body: jsonEncode({'text': provider.rawText ?? provider.text}),
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -43,9 +43,20 @@ class _LoadingScreenState extends State<LoadingScreen> {
           Navigator.pushNamed(context, Routes.analysis);
         }
       } else {
+        var message = 'Analysis failed';
+        try {
+          final decoded = jsonDecode(response.body);
+          if (decoded is Map<String, dynamic> && decoded['detail'] != null) {
+            message = decoded['detail'].toString();
+          } else {
+            message = decoded.toString();
+          }
+        } catch (_) {
+          if (response.body.isNotEmpty) message = response.body;
+        }
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Analysis failed')),
+            SnackBar(content: Text(message)),
           );
         }
       }


### PR DESCRIPTION
## Summary
- store raw extracted text separately from cleaned text
- send raw text to analysis when available
- surface server error messages in loading screen

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6889e0b88fd88329afe8d896ed5fd6e0