### PR TITLE
feat: compress and upload audio

### DIFF
--- a/frontend/learnsynth/lib/screens/audio_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_picker_screen.dart
@@ -1,19 +1,21 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_sound/flutter_sound.dart';
+import 'package:ffmpeg_kit_flutter_full_gpl/ffmpeg_kit.dart';
+import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import '../constants.dart';
 import '../content_provider.dart';
 import '../widgets/primary_button.dart';
 
-/// Screen allowing the user to either record a new clip or pick an
-/// existing audio file from device storage. Once a file is obtained it
-/// is stored in [ContentProvider] and the user is taken to the loading
-/// screen for processing.
+/// Screen that lets the user select an audio file, compress it and upload it
+/// to the backend. The backend returns cleaned text which is stored in
+/// [ContentProvider] for later processing.
 class AudioPickerScreen extends StatefulWidget {
   const AudioPickerScreen({super.key});
 
@@ -22,50 +24,81 @@ class AudioPickerScreen extends StatefulWidget {
 }
 
 class _AudioPickerScreenState extends State<AudioPickerScreen> {
-  final FlutterSoundRecorder _recorder = FlutterSoundRecorder();
-  bool _isRecording = false;
+  bool _isProcessing = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _recorder.openRecorder();
-  }
-
-  @override
-  void dispose() {
-    _recorder.closeRecorder();
-    super.dispose();
-  }
-
-  Future<void> _toggleRecording() async {
-    if (_isRecording) {
-      final path = await _recorder.stopRecorder();
-      setState(() => _isRecording = false);
-      if (path != null) {
-        _handleSelected(File(path));
+  Future<void> _pickAudio() async {
+    try {
+      if (Platform.isAndroid) {
+        final status = await Permission.storage.request();
+        if (!status.isGranted) {
+          _showError('Storage permission denied');
+          return;
+        }
       }
-    } else {
+
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['mp3', 'wav', 'm4a'],
+      );
+      if (result != null && result.files.single.path != null) {
+        final file = File(result.files.single.path!);
+        final compressed = await _compressAudio(file);
+        if (compressed != null) {
+          await _uploadAudio(compressed);
+        } else {
+          _showError('Compression failed');
+        }
+      }
+    } catch (e) {
+      _showError(e.toString());
+    }
+  }
+
+  Future<File?> _compressAudio(File input) async {
+    try {
       final dir = await getTemporaryDirectory();
-      final path =
-          '${dir.path}/recording_${DateTime.now().millisecondsSinceEpoch}.m4a';
-      await _recorder.startRecorder(toFile: path, codec: Codec.aacMP4);
-      setState(() => _isRecording = true);
+      final outPath = '${dir.path}/compressed_audio.mp3';
+      await FFmpegKit.execute('-i "${input.path}" -b:a 64k -y "$outPath"');
+      final output = File(outPath);
+      return output.existsSync() ? output : null;
+    } catch (_) {
+      return null;
     }
   }
 
-  Future<void> _pickFromFiles() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['mp3', 'wav', 'm4a'],
+  Future<void> _uploadAudio(File file) async {
+    setState(() => _isProcessing = true);
+    try {
+      final request = http.MultipartRequest(
+        'POST',
+        Uri.parse('http://10.0.2.2:8000/upload-audio'),
+      );
+      request.files.add(await http.MultipartFile.fromPath('file', file.path));
+
+      final streamed = await request.send();
+      final response = await http.Response.fromStream(streamed);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final cleanedText = data['cleaned_text'] as String? ?? '';
+        context.read<ContentProvider>().setText(cleanedText);
+        if (mounted) {
+          Navigator.pushNamed(context, Routes.loading);
+        }
+      } else {
+        _showError('Upload failed: ${response.statusCode}');
+      }
+    } catch (e) {
+      _showError('Upload failed');
+    } finally {
+      if (mounted) setState(() => _isProcessing = false);
+    }
+  }
+
+  void _showError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
-    if (result != null && result.files.single.path != null) {
-      _handleSelected(File(result.files.single.path!));
-    }
-  }
-
-  void _handleSelected(File file) {
-    context.read<ContentProvider>().setAudioFile(file);
-    Navigator.pushNamed(context, Routes.loading);
   }
 
   @override
@@ -78,13 +111,8 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             PrimaryButton(
-              label: _isRecording ? 'Stop Recording' : 'Record Audio',
-              onPressed: _toggleRecording,
-            ),
-            const SizedBox(height: 16),
-            PrimaryButton(
-              label: 'Choose from Files',
-              onPressed: _pickFromFiles,
+              label: 'Select Audio File',
+              onPressed: _isProcessing ? null : _pickAudio,
             ),
           ],
         ),

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -38,7 +38,8 @@ dependencies:
   provider: ^6.1.1
   http: ^1.4.0
   video_compress: ^3.1.2
-  flutter_sound: ^9.2.13
+  ffmpeg_kit_flutter_full_gpl: ^4.5.1
+  permission_handler: ^11.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- allow selecting and compressing audio before upload
- use `/upload-audio` endpoint and store cleaned text in provider
- add ffmpeg kit and permission handler dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688db306fcb08329b07a5bc20fc882bf