### PR TITLE
feat: local audio transcription

### DIFF
--- a/frontend/learnsynth/lib/screens/loading_screen.dart
+++ b/frontend/learnsynth/lib/screens/loading_screen.dart
@@ -22,7 +22,14 @@ class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    _analyze();
+    final provider = Provider.of<ContentProvider>(context, listen: false);
+    if (provider.summary != null && provider.summary!.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => Navigator.pushNamed(context, Routes.analysis),
+      );
+    } else {
+      _analyze();
+    }
   }
 
   Future<void> _analyze() async {

--- a/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,13 +5,11 @@
 import FlutterMacOS
 import Foundation
 
-import ffmpeg_kit_flutter_full_gpl
 import file_picker
 import path_provider_foundation
 import video_compress
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   VideoCompressPlugin.register(with: registry.registrar(forPlugin: "VideoCompressPlugin"))

--- a/frontend/learnsynth/pubspec.lock
+++ b/frontend/learnsynth/pubspec.lock
@@ -73,22 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  ffmpeg_kit_flutter_full_gpl:
-    dependency: "direct main"
-    description:
-      name: ffmpeg_kit_flutter_full_gpl
-      sha256: "30ffbb42abac7a86e392768494e0a53584f53dd37770a17efea47201c90fb6b9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.1"
-  ffmpeg_kit_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: ffmpeg_kit_flutter_platform_interface
-      sha256: addf046ae44e190ad0101b2fde2ad909a3cd08a2a109f6106d2f7048b7abedee
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   file_picker:
     dependency: "direct main"
     description:

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -34,11 +34,9 @@ dependencies:
 
   # Allows picking local files for the mocked upload flow.
   file_picker: ^10.2.0
-  path_provider: ^2.1.1
   provider: ^6.1.1
   http: ^1.4.0
   video_compress: ^3.1.2
-  ffmpeg_kit_flutter_full_gpl: ^4.5.1
   permission_handler: ^11.3.0
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- replace FFmpeg upload flow with local audio transcription and analysis
- skip redundant backend analysis when summary already exists
- remove FFmpeg dependency and plugin registration

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format frontend/learnsynth/lib/screens/audio_picker_screen.dart frontend/learnsynth/lib/screens/loading_screen.dart frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift frontend/learnsynth/pubspec.yaml frontend/learnsynth/pubspec.lock` *(fails: command not found)*
- `dart analyze frontend/learnsynth` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_688dd124a1048329ae8b204cb0aa72ff