### PR TITLE
feat: transcribe video locally and process analysis

### DIFF
--- a/frontend/learnsynth/lib/screens/loading_screen.dart
+++ b/frontend/learnsynth/lib/screens/loading_screen.dart
@@ -22,7 +22,18 @@ class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    _analyze();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkAndAnalyze());
+  }
+
+  Future<void> _checkAndAnalyze() async {
+    final provider = Provider.of<ContentProvider>(context, listen: false);
+    if (provider.summary != null && provider.summary!.isNotEmpty) {
+      if (mounted) {
+        Navigator.pushNamed(context, Routes.analysis);
+      }
+      return;
+    }
+    await _analyze();
   }
 
   Future<void> _analyze() async {

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -37,7 +37,6 @@ dependencies:
   path_provider: ^2.1.1
   provider: ^6.1.1
   http: ^1.4.0
-  video_compress: ^3.1.2
   ffmpeg_kit_flutter_full_gpl: ^4.5.1
   permission_handler: ^11.3.0
 


### PR DESCRIPTION
## Summary
- remove video compression and raw video upload in video picker
- transcribe picked videos locally, upload transcript, then analyze
- skip redundant analysis in LoadingScreen and drop unused dependency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd2b3d7e48329b2665b86828b86fe