### PR TITLE
feat: add local transcription for media inputs

### DIFF
--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -36,8 +36,10 @@ dependencies:
   file_picker: ^10.2.0
   provider: ^6.1.1
   http: ^1.4.0
-  video_compress: ^3.1.2
   permission_handler: ^11.3.0
+  ffmpeg_kit_flutter: any
+  whisper_dart: any
+  syncfusion_flutter_pdf: any
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- process picked audio locally with FFmpegKit and stub STT
- extract video audio track and transcribe locally
- parse selected PDFs on device via Syncfusion
- add required media processing dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688dd647a0a883299994c0d8baac1d2c