### PR TITLE
Add media and PDF dependencies

### DIFF
--- a/frontend/learnsynth/README.md
+++ b/frontend/learnsynth/README.md
@@ -18,5 +18,5 @@ samples, guidance on mobile development, and a full API reference.
 Video compression previously relied on the `flutter_video_compress` package.
 This dependency has been removed for compatibility with recent Flutter
 versions. If compression functionality is needed in the future, consider using
-[`ffmpeg_kit_flutter`](https://github.com/tanersener/ffmpeg-kit) which is better
+[`ffmpeg_kit_flutter_min_gpl`](https://github.com/tanersener/ffmpeg-kit) which is better
 maintained and offers extensive media processing features.

--- a/frontend/learnsynth/lib/screens/audio_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_picker_screen.dart
@@ -4,7 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
-import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
 import 'package:whisper_dart/whisper_dart.dart' as whisper; // ignore: unused_import
 
 import '../constants.dart';

--- a/frontend/learnsynth/lib/screens/video_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/video_picker_screen.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
 import 'package:whisper_dart/whisper_dart.dart' as whisper; // ignore: unused_import
 
 import '../widgets/primary_button.dart';

--- a/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,8 @@ import Foundation
 
 import file_picker
 import path_provider_foundation
-import video_compress
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  VideoCompressPlugin.register(with: registry.registrar(forPlugin: "VideoCompressPlugin"))
 }

--- a/frontend/learnsynth/pubspec.lock
+++ b/frontend/learnsynth/pubspec.lock
@@ -389,14 +389,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  video_compress:
-    dependency: "direct main"
-    description:
-      name: video_compress
-      sha256: "31bc5cdb9a02ba666456e5e1907393c28e6e0e972980d7d8d619a7beda0d4f20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.4"
   vm_service:
     dependency: transitive
     description:

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -37,9 +37,9 @@ dependencies:
   provider: ^6.1.1
   http: ^1.4.0
   permission_handler: ^11.3.0
-  ffmpeg_kit_flutter: any
-  whisper_dart: any
-  syncfusion_flutter_pdf: any
+  ffmpeg_kit_flutter_min_gpl: ^6.0.3
+  whisper_dart: ^0.6.0
+  syncfusion_flutter_pdf: ^27.1.58
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- switch to `ffmpeg_kit_flutter_min_gpl` and add STT and PDF packages
- clean up old video_compress plugin and update references

## Testing
- `flutter pub get` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git /tmp/flutter` *(fails: CONNECT tunnel failed 403)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688dd841c35083299c74d068be5faa27