### PR TITLE
Refactor transcription handling

### DIFF
--- a/frontend/learnsynth/lib/screens/audio_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_picker_screen.dart
@@ -4,8 +4,8 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
-import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
-import 'package:whisper_dart/whisper_dart.dart' as whisper; // ignore: unused_import
+
+import '../services/transcription_service.dart';
 
 import '../constants.dart';
 import '../content_provider.dart';
@@ -46,8 +46,8 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
           _transcript = null;
         });
 
-        final wavFile = await _ensureWav(_selectedFile!);
-        final transcription = await _transcribeAudio(wavFile);
+        final transcription =
+            await TranscriptionService().transcribeAudio(_selectedFile!);
         if (!mounted) return;
         context.read<ContentProvider>().setText(transcription);
         setState(() {
@@ -61,21 +61,6 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
     }
   }
 
-  Future<File> _ensureWav(File file) async {
-    final path = file.path;
-    if (path.toLowerCase().endsWith('.wav')) {
-      return file;
-    }
-    final outPath = '${path}_converted.wav';
-    await FFmpegKit.execute('-i "$path" -ac 1 -ar 16000 "$outPath"');
-    return File(outPath);
-  }
-
-  Future<String> _transcribeAudio(File file) async {
-    // TODO: Replace with real transcription using whisper_dart or another STT package.
-    await Future.delayed(const Duration(seconds: 1));
-    return 'Transcription placeholder';
-  }
 
   void _continue() {
     Navigator.pushNamed(context, Routes.loading);

--- a/frontend/learnsynth/lib/screens/video_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/video_picker_screen.dart
@@ -3,12 +3,10 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
-import 'package:whisper_dart/whisper_dart.dart' as whisper; // ignore: unused_import
-
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
+import '../services/transcription_service.dart';
 
 /// Picks a video file, extracts the audio track, and transcribes it locally.
 class VideoPickerScreen extends StatefulWidget {
@@ -33,10 +31,9 @@ class _VideoPickerScreenState extends State<VideoPickerScreen> {
       });
 
       try {
-        final audioPath = '${_videoFile!.path}_audio.wav';
-        await FFmpegKit.execute(
-            '-i "${_videoFile!.path}" -vn -acodec pcm_s16le -ar 16000 -ac 1 "$audioPath"');
-        final text = await _transcribeAudio(File(audioPath));
+        final service = TranscriptionService();
+        final audioFile = await service.extractAudioFromVideo(_videoFile!);
+        final text = await service.transcribeAudio(audioFile);
         if (!mounted) return;
         context.read<ContentProvider>().setText(text);
         setState(() {
@@ -50,11 +47,6 @@ class _VideoPickerScreenState extends State<VideoPickerScreen> {
     }
   }
 
-  Future<String> _transcribeAudio(File file) async {
-    // TODO: Replace with real transcription using whisper_dart or another STT package.
-    await Future.delayed(const Duration(seconds: 1));
-    return 'Transcription placeholder';
-  }
 
   void _continue() {
     Navigator.pushNamed(context, Routes.loading);

--- a/frontend/learnsynth/lib/services/transcription_service.dart
+++ b/frontend/learnsynth/lib/services/transcription_service.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+/// Provides audio transcription utilities.
+///
+/// Actual transcription and audio processing logic will be implemented in a
+/// future revision. For now, these methods return placeholder values so the
+/// rest of the application can be wired up.
+class TranscriptionService {
+  /// Transcribes the given [audioFile] and returns the recognized text.
+  Future<String> transcribeAudio(File audioFile) async {
+    // TODO: Integrate with a real speech-to-text library.
+    await Future.delayed(const Duration(seconds: 1));
+    return 'Transcription placeholder';
+  }
+
+  /// Extracts the audio track from a [videoFile].
+  ///
+  /// The current stub simply returns the [videoFile] itself. In a real
+  /// implementation this would return a path to a newly generated audio file
+  /// (for example, a WAV file).
+  Future<File> extractAudioFromVideo(File videoFile) async {
+    // TODO: Implement audio extraction from video.
+    return videoFile;
+  }
+}
+

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -37,8 +37,6 @@ dependencies:
   provider: ^6.1.1
   http: ^1.4.0
   permission_handler: ^11.3.0
-  ffmpeg_kit_flutter_min_gpl: ^6.0.3
-  whisper_dart: ^0.6.0
   syncfusion_flutter_pdf: ^27.1.58
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- remove ffmpeg_kit_flutter_min_gpl and whisper_dart dependencies
- add TranscriptionService with stubbed audio handling
- update audio and video pickers to use new service

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ddfe866688329b226f2f2cbce6c91