### PR TITLE
Fetch method activities on selection screen

### DIFF
--- a/frontend/learnsynth/lib/content_provider.dart
+++ b/frontend/learnsynth/lib/content_provider.dart
@@ -26,6 +26,7 @@ class ContentProvider extends ChangeNotifier {
   Map<String, dynamic>? conceptMap;
   List<Map<String, dynamic>> contextualExercises = [];
   List<Map<String, dynamic>> evaluationQuestions = [];
+  Map<String, String> activitySummaries = {};
   final List<ContentItem> _saved = [];
 
   /// List of all content pieces added by the user.
@@ -108,6 +109,11 @@ class ContentProvider extends ChangeNotifier {
 
   void setEvaluationQuestions(List<Map<String, dynamic>> list) {
     evaluationQuestions = list;
+    notifyListeners();
+  }
+
+  void setActivitySummaries(Map<String, String> summaries) {
+    activitySummaries = summaries;
     notifyListeners();
   }
 

--- a/frontend/learnsynth/lib/screens/method_selection_screen.dart
+++ b/frontend/learnsynth/lib/screens/method_selection_screen.dart
@@ -1,47 +1,116 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 import '../widgets/method_card.dart';
 import '../constants.dart';
+import '../content_provider.dart';
 
 /// Lists the available study methods. Each card navigates to its
 /// corresponding screen using a named route.
-class MethodSelectionScreen extends StatelessWidget {
+class MethodSelectionScreen extends StatefulWidget {
   const MethodSelectionScreen({super.key});
 
   @override
+  State<MethodSelectionScreen> createState() => _MethodSelectionScreenState();
+}
+
+class _MethodSelectionScreenState extends State<MethodSelectionScreen> {
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchActivities();
+  }
+
+  Future<void> _fetchActivities() async {
+    final provider = Provider.of<ContentProvider>(context, listen: false);
+    if (provider.activitySummaries.isNotEmpty) {
+      setState(() => _loading = false);
+      return;
+    }
+    final text = provider.content;
+    if (text == null || text.isEmpty) {
+      setState(() => _loading = false);
+      return;
+    }
+    try {
+      final url = Uri.parse('http://10.0.2.2:8000/analyze');
+      final response = await http.post(
+        url,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'text': text}),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final summaries =
+            Map<String, String>.from(data['activities'] as Map? ?? {});
+        provider.setActivitySummaries(summaries);
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to load activities')),
+          );
+        }
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Network error')),
+        );
+      }
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final summaries = context.watch<ContentProvider>().activitySummaries;
     return Scaffold(
       appBar: AppBar(title: const Text('Study Methods')),
-      body: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: ListView(
-          children: [
-            MethodCard(
-              icon: Icons.lightbulb_outline,
-              title: 'Deep Understanding',
-              description: 'Listen to explanations and see concept maps.',
-              onTap: () => Navigator.pushNamed(context, Routes.deepUnderstanding),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: ListView(
+                children: [
+                  MethodCard(
+                    icon: Icons.lightbulb_outline,
+                    title: 'Deep Understanding',
+                    description:
+                        'Listen to explanations and see concept maps.',
+                    summary: summaries['deep_understanding'],
+                    onTap: () =>
+                        Navigator.pushNamed(context, Routes.deepUnderstanding),
+                  ),
+                  MethodCard(
+                    icon: Icons.memory,
+                    title: 'Memorization',
+                    description: 'Use flashcards to remember key points.',
+                    summary: summaries['memorization'],
+                    onTap: () =>
+                        Navigator.pushNamed(context, Routes.memorization),
+                  ),
+                  MethodCard(
+                    icon: Icons.share,
+                    title: 'Contextual Association',
+                    description: 'Relate concepts to real-life scenarios.',
+                    summary: summaries['contextual_association'],
+                    onTap: () => Navigator.pushNamed(
+                        context, Routes.contextualAssociation),
+                  ),
+                  MethodCard(
+                    icon: Icons.quiz,
+                    title: 'Interactive Evaluation',
+                    description: 'Answer quiz questions to test knowledge.',
+                    summary: summaries['interactive_evaluation'],
+                    onTap: () => Navigator.pushNamed(
+                        context, Routes.interactiveEvaluation),
+                  ),
+                ],
+              ),
             ),
-            MethodCard(
-              icon: Icons.memory,
-              title: 'Memorization',
-              description: 'Use flashcards to remember key points.',
-              onTap: () => Navigator.pushNamed(context, Routes.memorization),
-            ),
-            MethodCard(
-              icon: Icons.share,
-              title: 'Contextual Association',
-              description: 'Relate concepts to real-life scenarios.',
-              onTap: () => Navigator.pushNamed(context, Routes.contextualAssociation),
-            ),
-            MethodCard(
-              icon: Icons.quiz,
-              title: 'Interactive Evaluation',
-              description: 'Answer quiz questions to test knowledge.',
-              onTap: () => Navigator.pushNamed(context, Routes.interactiveEvaluation),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/frontend/learnsynth/lib/widgets/method_card.dart
+++ b/frontend/learnsynth/lib/widgets/method_card.dart
@@ -8,6 +8,7 @@ class MethodCard extends StatelessWidget {
   final IconData icon;
   final String title;
   final String description;
+  final String? summary;
   final VoidCallback onTap;
 
   const MethodCard({
@@ -15,6 +16,7 @@ class MethodCard extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.description,
+    this.summary,
     required this.onTap,
   });
 
@@ -44,6 +46,13 @@ class MethodCard extends StatelessWidget {
                       description,
                       style: const TextStyle(color: Colors.white70),
                     ),
+                    if (summary != null && summary!.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        summary!,
+                        style: const TextStyle(color: Colors.white60, fontSize: 12),
+                      ),
+                    ],
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- convert method selection screen to stateful and fetch `/analyze` results on init
- store activity summaries in `ContentProvider`
- extend method cards to display fetched summaries

## Testing
- `dart format learnsynth/lib/content_provider.dart learnsynth/lib/widgets/method_card.dart learnsynth/lib/screens/method_selection_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689052db44e0832994a474ca9d09b852