### PR TITLE
feat: fetch progress metrics from backend

### DIFF
--- a/frontend/learnsynth/lib/screens/progress_screen.dart
+++ b/frontend/learnsynth/lib/screens/progress_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+
+import '../content_provider.dart';
 import '../widgets/progress_summary_card.dart';
 import '../widgets/quote_card.dart';
-import '../constants.dart';
-import 'package:provider/provider.dart';
-import '../content_provider.dart';
 
 /// Displays summary statistics for the user’s progress. Navigation back
 /// to the home page is provided by the bottom navigation bar, so we
@@ -11,27 +14,79 @@ import '../content_provider.dart';
 class ProgressScreen extends StatelessWidget {
   const ProgressScreen({super.key});
 
+  /// Fetches progress stats for the current content.
+  Future<Map<String, dynamic>> _fetchProgress(BuildContext context) async {
+    final provider = Provider.of<ContentProvider>(context, listen: false);
+    try {
+      final url = Uri.parse('http://10.0.2.2:8000/progress');
+      final response = await http.post(
+        url,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'text': provider.content ?? ''}),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        return {
+          'completedSessions': data['completedSessions'] ?? 0,
+          'studyTime': data['studyTime'] ?? '0m',
+          'methodsUsed': data['methodsUsed'] ?? 0,
+        };
+      } else {
+        throw Exception('Failed to load progress');
+      }
+    } catch (_) {
+      throw Exception('Failed to load progress');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
-    // TODO: POST /review/{id} to fetch progress
     return Scaffold(
       appBar: AppBar(title: const Text('Progress')),
-      body: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: ListView(
-          children: [
-            const ProgressSummaryCard(title: 'Completed Sessions', value: '5'),
-            const SizedBox(height: 16),
-            const ProgressSummaryCard(title: 'Study Time', value: '2h 30m'),
-            const SizedBox(height: 16),
-            const ProgressSummaryCard(title: 'Methods Used', value: '3'),
-            const SizedBox(height: 16),
-            // Navigation back to home is handled by the bottom nav bar.
-            // We show a motivational quote instead of a button.
-            const QuoteCard(quote: 'Keep up the great work!'),
-          ],
-        ),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _fetchProgress(context),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError || !snapshot.hasData) {
+            return Center(
+              child: Text(
+                'Could not load progress',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyLarge
+                    ?.copyWith(color: Colors.white70),
+              ),
+            );
+          }
+          final progress = snapshot.data!;
+          return Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: ListView(
+              children: [
+                ProgressSummaryCard(
+                  title: 'Completed Sessions',
+                  value: '${progress['completedSessions']}',
+                ),
+                const SizedBox(height: 16),
+                ProgressSummaryCard(
+                  title: 'Study Time',
+                  value: progress['studyTime'].toString(),
+                ),
+                const SizedBox(height: 16),
+                ProgressSummaryCard(
+                  title: 'Methods Used',
+                  value: '${progress['methodsUsed']}',
+                ),
+                const SizedBox(height: 16),
+                // Navigation back to home is handled by the bottom nav bar.
+                // We show a motivational quote instead of a button.
+                const QuoteCard(quote: 'Keep up the great work!'),
+              ],
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- dynamically load progress stats by posting current content to backend
- show returned study metrics in summary cards while keeping dark theme

## Testing
- `dart format frontend/learnsynth/lib/screens/progress_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890636e50d8832998f6cf41361b386f