### PR TITLE
Store file path alongside extracted text

### DIFF
--- a/frontend/learnsynth/lib/screens/audio_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/audio_picker_screen.dart
@@ -63,7 +63,10 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
         return;
       }
       if (!mounted) return;
-      context.read<ContentProvider>().setContent(transcription);
+      context.read<ContentProvider>().setFileContent(
+        path: _selectedFile!.path,
+        content: transcription,
+      );
       setState(() {
         _transcript = transcription;
         _isProcessing = false;

--- a/frontend/learnsynth/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/pdf_picker_screen.dart
@@ -47,7 +47,10 @@ class _PdfPickerScreenState extends State<PdfPickerScreen> {
       final extracted = PdfTextExtractor(document).extractText();
       document.dispose();
       if (!mounted) return;
-      context.read<ContentProvider>().setContent(extracted);
+      context.read<ContentProvider>().setFileContent(
+        path: _file!.path,
+        content: extracted,
+      );
       setState(() {
         _text = extracted;
         _isProcessing = false;

--- a/frontend/learnsynth/lib/screens/video_picker_screen.dart
+++ b/frontend/learnsynth/lib/screens/video_picker_screen.dart
@@ -55,7 +55,10 @@ class _VideoPickerScreenState extends State<VideoPickerScreen> {
         return;
       }
       if (!mounted) return;
-      context.read<ContentProvider>().setContent(text);
+      context.read<ContentProvider>().setFileContent(
+        path: _videoFile!.path,
+        content: text,
+      );
       setState(() {
         _transcript = text;
         _isProcessing = false;


### PR DESCRIPTION
## Summary
- save audio transcription with its source file path
- include video file path when storing transcription
- keep PDF file path when extracting text

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907db64c4c8329be6781c4ba4007a7