### PR TITLE
Fetch study data once and cache

### DIFF
--- a/frontend/learnsynth/lib/content_provider.dart
+++ b/frontend/learnsynth/lib/content_provider.dart
@@ -27,6 +27,7 @@ class ContentProvider extends ChangeNotifier {
   List<Map<String, dynamic>> contextualExercises = [];
   List<Map<String, dynamic>> evaluationQuestions = [];
   Map<String, String> activitySummaries = {};
+  Map<String, dynamic> progress = {};
   final List<ContentItem> _saved = [];
 
   /// List of all content pieces added by the user.
@@ -114,6 +115,11 @@ class ContentProvider extends ChangeNotifier {
 
   void setActivitySummaries(Map<String, String> summaries) {
     activitySummaries = summaries;
+    notifyListeners();
+  }
+
+  void setProgress(Map<String, dynamic> prog) {
+    progress = prog;
     notifyListeners();
   }
 

--- a/frontend/learnsynth/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learnsynth/lib/screens/interactive_evaluation_screen.dart
@@ -1,67 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import '../widgets/quiz_question_card.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
-import 'package:provider/provider.dart';
 import '../content_provider.dart';
-import 'dart:convert';
-import 'package:http/http.dart' as http;
 
 /// Presents an interactive quiz. After submitting answers, the user can
 /// complete the session which navigates to the progress screen using
 /// [Navigator.pushNamed].
-class InteractiveEvaluationScreen extends StatefulWidget {
+class InteractiveEvaluationScreen extends StatelessWidget {
   const InteractiveEvaluationScreen({super.key});
-
-  @override
-  State<InteractiveEvaluationScreen> createState() =>
-      _InteractiveEvaluationScreenState();
-}
-
-class _InteractiveEvaluationScreenState
-    extends State<InteractiveEvaluationScreen> {
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetch();
-  }
-
-  Future<void> _fetch() async {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
-    if (provider.evaluationQuestions.isNotEmpty) {
-      setState(() => _loading = false);
-      return;
-    }
-    try {
-      final url = Uri.parse('http://10.0.2.2:8000/analyze');
-      final response = await http.post(
-        url,
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(
-            {'text': provider.content, 'mode': 'interactive_evaluation'}),
-      );
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final questions =
-            (data['evaluationQuestions'] as List? ?? [])
-                .map<Map<String, dynamic>>(
-                    (e) => Map<String, dynamic>.from(e as Map))
-                .toList();
-        provider.setEvaluationQuestions(questions);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load questions')),
-        );
-      }
-    } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Network error')),
-      );
-    }
-    if (mounted) setState(() => _loading = false);
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -70,47 +19,46 @@ class _InteractiveEvaluationScreenState
       appBar: AppBar(title: const Text('Interactive Evaluation')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: _loading
-            ? const Center(child: CircularProgressIndicator())
-            : Column(
-                children: [
-                  if (exercises.isNotEmpty)
-                    Expanded(
-                      child: ListView.separated(
-                        itemCount: exercises.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 16),
-                        itemBuilder: (context, index) {
-                          final ex = exercises[index];
-                          if (ex.containsKey('choices')) {
-                            return QuizQuestionCard(
-                              question: ex['question'] ?? '',
-                              choices:
-                                  List<String>.from(ex['choices'] ?? const []),
-                              correctIndex: ex['correctIndex'] as int? ?? 0,
-                            );
-                          }
-                          return Card(
-                            child: Padding(
-                              padding: const EdgeInsets.all(16.0),
-                              child: Text(ex['question']?.toString() ?? ex.toString()),
-                            ),
-                          );
-                        },
+        child: Column(
+          children: [
+            if (exercises.isNotEmpty)
+              Expanded(
+                child: ListView.separated(
+                  itemCount: exercises.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final ex = exercises[index];
+                    if (ex.containsKey('choices')) {
+                      return QuizQuestionCard(
+                        question: ex['question'] ?? '',
+                        choices: List<String>.from(ex['choices'] ?? const []),
+                        correctIndex: ex['correctIndex'] as int? ?? 0,
+                      );
+                    }
+                    return Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Text(
+                            ex['question']?.toString() ?? ex.toString()),
                       ),
-                    )
-                  else
-                    const Text('No questions generated'),
-                  const SizedBox(height: 16),
-                  PrimaryButton(label: 'Submit', onPressed: () {}),
-                  const SizedBox(height: 16),
-                  PrimaryButton(
-                    label: 'Complete Session',
-                    onPressed: () =>
-                        Navigator.pushNamed(context, Routes.progress),
-                  ),
-                ],
-              ),
+                    );
+                  },
+                ),
+              )
+            else
+              const Text('No questions generated'),
+            const SizedBox(height: 16),
+            PrimaryButton(label: 'Submit', onPressed: () {}),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              label: 'Complete Session',
+              onPressed: () =>
+                  Navigator.pushNamed(context, Routes.progress),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
+

--- a/frontend/learnsynth/lib/screens/loading_screen.dart
+++ b/frontend/learnsynth/lib/screens/loading_screen.dart
@@ -43,9 +43,38 @@ class _LoadingScreenState extends State<LoadingScreen> {
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final summary = data['summary'] as String? ?? '';
-        final topics = List<String>.from(data['topics'] as List? ?? []);
-        provider.setAnalysis(summary, topics);
+        provider.setAnalysis(
+          data['summary'] as String? ?? '',
+          List<String>.from(data['topics'] as List? ?? []),
+        );
+        provider.setFlashcards(
+          (data['flashcards'] as List? ?? [])
+              .map<Map<String, String>>(
+                  (e) => Map<String, String>.from(e as Map))
+              .toList(),
+        );
+        final conceptMap = data['concept_map'] as Map?;
+        if (conceptMap != null) {
+          provider.setConceptMap(Map<String, dynamic>.from(conceptMap));
+        }
+        provider.setContextualExercises(
+          (data['contextual_exercises'] as List? ?? [])
+              .map<Map<String, dynamic>>(
+                  (e) => Map<String, dynamic>.from(e as Map))
+              .toList(),
+        );
+        provider.setEvaluationQuestions(
+          ((data['quiz'] ?? data['evaluation_questions']) as List? ?? [])
+              .map<Map<String, dynamic>>(
+                  (e) => Map<String, dynamic>.from(e as Map))
+              .toList(),
+        );
+        provider.setActivitySummaries(
+          Map<String, String>.from(data['activities'] as Map? ?? {}),
+        );
+        provider.setProgress(
+          Map<String, dynamic>.from(data['progress'] as Map? ?? {}),
+        );
         if (mounted) {
           Navigator.pushNamed(context, Routes.analysis);
         }

--- a/frontend/learnsynth/lib/screens/memorization_screen.dart
+++ b/frontend/learnsynth/lib/screens/memorization_screen.dart
@@ -1,111 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import '../widgets/flashcard_widget.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
-import 'package:provider/provider.dart';
 import '../content_provider.dart';
-import 'dart:convert';
-import 'package:http/http.dart' as http;
 
 /// Presents flashcard‑style activities for memorization. Buttons for
 /// grading difficulty are included. Completion navigates to the
 /// progress screen via [Navigator.pushNamed].
-class MemorizationScreen extends StatefulWidget {
+class MemorizationScreen extends StatelessWidget {
   const MemorizationScreen({super.key});
 
   @override
-  State<MemorizationScreen> createState() => _MemorizationScreenState();
-}
-
-class _MemorizationScreenState extends State<MemorizationScreen> {
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetch();
-  }
-
-  Future<void> _fetch() async {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
-    if (provider.flashcards.isNotEmpty) {
-      setState(() => _loading = false);
-      return;
-    }
-    try {
-      final url = Uri.parse('http://10.0.2.2:8000/analyze');
-      final response = await http.post(
-        url,
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'text': provider.content, 'mode': 'memorization'}),
-      );
-      if (response.statusCode == 200) {
-        try {
-          final data = jsonDecode(response.body);
-          final list =
-              (data['flashcards'] ?? data['cards'] ?? data['result']?['flashcards'] ?? data['result']?['cards'])
-                  as List?;
-          final cards = list
-                  ?.map<Map<String, String>>(
-                      (e) => Map<String, String>.from(e as Map))
-                  .toList() ??
-              [];
-          provider.setFlashcards(cards);
-        } catch (_) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Invalid flashcard data')),
-          );
-        }
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load flashcards')),
-        );
-      }
-    } catch (_) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Network error')),
-      );
-    }
-    if (mounted) setState(() => _loading = false);
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
-    final cards = provider.flashcards;
+    final cards = context.watch<ContentProvider>().flashcards;
     return Scaffold(
       appBar: AppBar(title: const Text('Memorization')),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: _loading
-            ? const Center(child: CircularProgressIndicator())
-            : Column(
-                children: [
-                  if (cards.isNotEmpty)
-                    Expanded(
-                      child: ListView.separated(
-                        itemCount: cards.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 16),
-                        itemBuilder: (context, index) {
-                          final c = cards[index];
-                          return FlashcardWidget(
-                            question: c['question'] ?? '',
-                            answer: c['answer'] ?? '',
-                          );
-                        },
-                      ),
-                    )
-                  else
-                    const Text('No flashcards generated'),
-                  const SizedBox(height: 16),
-                  PrimaryButton(
-                    label: 'Complete Session',
-                    onPressed: () =>
-                        Navigator.pushNamed(context, Routes.progress),
-                  ),
-                ],
-              ),
+        child: Column(
+          children: [
+            if (cards.isNotEmpty)
+              Expanded(
+                child: ListView.separated(
+                  itemCount: cards.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final c = cards[index];
+                    return FlashcardWidget(
+                      question: c['question'] ?? '',
+                      answer: c['answer'] ?? '',
+                    );
+                  },
+                ),
+              )
+            else
+              const Text('No flashcards generated'),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              label: 'Complete Session',
+              onPressed: () =>
+                  Navigator.pushNamed(context, Routes.progress),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
+

--- a/frontend/learnsynth/lib/screens/method_selection_screen.dart
+++ b/frontend/learnsynth/lib/screens/method_selection_screen.dart
@@ -1,116 +1,59 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'dart:convert';
-import 'package:http/http.dart' as http;
+
 import '../widgets/method_card.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 
 /// Lists the available study methods. Each card navigates to its
 /// corresponding screen using a named route.
-class MethodSelectionScreen extends StatefulWidget {
+class MethodSelectionScreen extends StatelessWidget {
   const MethodSelectionScreen({super.key});
-
-  @override
-  State<MethodSelectionScreen> createState() => _MethodSelectionScreenState();
-}
-
-class _MethodSelectionScreenState extends State<MethodSelectionScreen> {
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchActivities();
-  }
-
-  Future<void> _fetchActivities() async {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
-    if (provider.activitySummaries.isNotEmpty) {
-      setState(() => _loading = false);
-      return;
-    }
-    final text = provider.content;
-    if (text == null || text.isEmpty) {
-      setState(() => _loading = false);
-      return;
-    }
-    try {
-      final url = Uri.parse('http://10.0.2.2:8000/analyze');
-      final response = await http.post(
-        url,
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'text': text}),
-      );
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final summaries =
-            Map<String, String>.from(data['activities'] as Map? ?? {});
-        provider.setActivitySummaries(summaries);
-      } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Failed to load activities')),
-          );
-        }
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Network error')),
-        );
-      }
-    }
-    if (mounted) setState(() => _loading = false);
-  }
 
   @override
   Widget build(BuildContext context) {
     final summaries = context.watch<ContentProvider>().activitySummaries;
     return Scaffold(
       appBar: AppBar(title: const Text('Study Methods')),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: ListView(
-                children: [
-                  MethodCard(
-                    icon: Icons.lightbulb_outline,
-                    title: 'Deep Understanding',
-                    description:
-                        'Listen to explanations and see concept maps.',
-                    summary: summaries['deep_understanding'],
-                    onTap: () =>
-                        Navigator.pushNamed(context, Routes.deepUnderstanding),
-                  ),
-                  MethodCard(
-                    icon: Icons.memory,
-                    title: 'Memorization',
-                    description: 'Use flashcards to remember key points.',
-                    summary: summaries['memorization'],
-                    onTap: () =>
-                        Navigator.pushNamed(context, Routes.memorization),
-                  ),
-                  MethodCard(
-                    icon: Icons.share,
-                    title: 'Contextual Association',
-                    description: 'Relate concepts to real-life scenarios.',
-                    summary: summaries['contextual_association'],
-                    onTap: () => Navigator.pushNamed(
-                        context, Routes.contextualAssociation),
-                  ),
-                  MethodCard(
-                    icon: Icons.quiz,
-                    title: 'Interactive Evaluation',
-                    description: 'Answer quiz questions to test knowledge.',
-                    summary: summaries['interactive_evaluation'],
-                    onTap: () => Navigator.pushNamed(
-                        context, Routes.interactiveEvaluation),
-                  ),
-                ],
-              ),
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: ListView(
+          children: [
+            MethodCard(
+              icon: Icons.lightbulb_outline,
+              title: 'Deep Understanding',
+              description: 'Listen to explanations and see concept maps.',
+              summary: summaries['deep_understanding'],
+              onTap: () =>
+                  Navigator.pushNamed(context, Routes.deepUnderstanding),
             ),
+            MethodCard(
+              icon: Icons.memory,
+              title: 'Memorization',
+              description: 'Use flashcards to remember key points.',
+              summary: summaries['memorization'],
+              onTap: () => Navigator.pushNamed(context, Routes.memorization),
+            ),
+            MethodCard(
+              icon: Icons.share,
+              title: 'Contextual Association',
+              description: 'Relate concepts to real-life scenarios.',
+              summary: summaries['contextual_association'],
+              onTap: () =>
+                  Navigator.pushNamed(context, Routes.contextualAssociation),
+            ),
+            MethodCard(
+              icon: Icons.quiz,
+              title: 'Interactive Evaluation',
+              description: 'Answer quiz questions to test knowledge.',
+              summary: summaries['interactive_evaluation'],
+              onTap: () =>
+                  Navigator.pushNamed(context, Routes.interactiveEvaluation),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- Load summary, flashcards, concept map, contextual exercises, quiz questions, activities, and progress in a single analysis call, caching results in the ContentProvider.
- Expose cached progress and other study data through new fields and setters.
- Remove per-screen HTTP requests; study screens now consume cached data directly from ContentProvider.

## Testing
- `dart format frontend/learnsynth/lib/content_provider.dart frontend/learnsynth/lib/screens/loading_screen.dart frontend/learnsynth/lib/screens/method_selection_screen.dart frontend/learnsynth/lib/screens/memorization_screen.dart frontend/learnsynth/lib/screens/deep_understanding_screen.dart frontend/learnsynth/lib/screens/contextual_association_screen.dart frontend/learnsynth/lib/screens/interactive_evaluation_screen.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907ea888408329bbd12eff2a80e17c