### PR TITLE
feat: update ffmpeg-kit to 6.x

### DIFF
--- a/frontend/learnsynth/lib/services/transcription_service.dart
+++ b/frontend/learnsynth/lib/services/transcription_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
-import 'package:ffmpeg_kit_flutter_min_gpl/return_code.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:speech_to_text/speech_recognition_result.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
@@ -33,9 +32,8 @@ class TranscriptionService {
       final session = await FFmpegKit.execute(
         '-y -i "${videoFile.path}" -vn -acodec pcm_s16le -ar 16000 -ac 1 "$outputPath"',
       );
-      final rc = await session.getReturnCode();
-      final code = rc?.getValue() ?? 1;
-      if (ReturnCode.isSuccess(rc)) {
+      final code = await session.getReturnCode() ?? 1;
+      if (code == 0) {
         return FfmpegResult(data: File(outputPath), returnCode: code);
       }
       return FfmpegResult<File>(data: null, returnCode: code);

--- a/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/learnsynth/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,6 @@ import FlutterMacOS
 import Foundation
 
 import audio_session
-import ffmpeg_kit_flutter
 import ffmpeg_kit_flutter_min_gpl
 import file_picker
 import just_audio
@@ -15,7 +14,6 @@ import speech_to_text_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
-  FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FFmpegKitFlutterPlugin.register(with: registry.registrar(forPlugin: "FFmpegKitFlutterPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))

--- a/frontend/learnsynth/pubspec.lock
+++ b/frontend/learnsynth/pubspec.lock
@@ -97,14 +97,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  ffmpeg_kit_flutter:
-    dependency: "direct main"
-    description:
-      name: ffmpeg_kit_flutter
-      sha256: "843aae41823ca94a0988d975b4b6cdc6948744b9b7e2707d81a3a9cd237b0100"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.3"
   ffmpeg_kit_flutter_min_gpl:
     dependency: "direct main"
     description:
@@ -112,7 +104,7 @@ packages:
       sha256: c60dc6354949cc760113d5858a9f4f1af5b46576a464222770ff796243fae40f
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "6.0.0"
   ffmpeg_kit_flutter_platform_interface:
     dependency: transitive
     description:

--- a/frontend/learnsynth/pubspec.yaml
+++ b/frontend/learnsynth/pubspec.yaml
@@ -38,9 +38,8 @@ dependencies:
   http: ^1.4.0
   permission_handler: ^11.3.0
   syncfusion_flutter_pdf: ^27.1.58
-  ffmpeg_kit_flutter_min_gpl: ^4.5.1
+  ffmpeg_kit_flutter_min_gpl: ^6.0.0
   speech_to_text: ^6.5.1
-  ffmpeg_kit_flutter: ^6.0.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- depend solely on ffmpeg_kit_flutter_min_gpl 6.x
- update transcription service for new ffmpeg-kit API
- remove unused ffmpeg_kit_flutter plugin registration

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689be64618d483299039feb216fa35fc