### PR TITLE
Fix Flutter plugin loader configuration for Android build

### DIFF
--- a/frontend/learnsynth/android/build.gradle.kts
+++ b/frontend/learnsynth/android/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.3" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }

--- a/frontend/learnsynth/android/settings.gradle.kts
+++ b/frontend/learnsynth/android/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary
- remove `dev.flutter.flutter-plugin-loader` from the Android root `build.gradle.kts`
- apply `dev.flutter.flutter-plugin-loader` in `settings.gradle.kts` as required by the plugin

## Testing
- `./gradlew tasks` *(fails: No such file or directory)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c16f1d2ac8329a4ea6c3364765f44