### PR TITLE
Use classic Flutter Gradle integration for Android app

### DIFF
--- a/frontend/learnsynth/android/app/build.gradle.kts
+++ b/frontend/learnsynth/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    
 }
 
 android {
@@ -21,8 +20,8 @@ android {
         applicationId = "com.example.learnsynth"
         minSdk = 24
         targetSdk = 34
-        versionCode = flutter.versionCode
-        versionName = flutter.versionName
+        versionCode = 1
+        versionName = "1.0"
     }
 
     buildTypes {
@@ -32,6 +31,6 @@ android {
     }
 }
 
-flutter {
-    source = "../.."
-}
+// Use the classic Flutter Gradle integration
+apply(from = "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle")
+


### PR DESCRIPTION
## Summary
- Replace Android app's `build.gradle.kts` with classic Flutter integration
- Hardcode `versionCode` and `versionName` instead of `flutter.*` properties

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c259a3eb08329b2e2d38898cbdb8d