### PR TITLE
feat: migrate frontend to riverpod and offline transcription

### DIFF
--- a/frontend/learn/lib/content_provider.dart
+++ b/frontend/learn/lib/content_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Simple model representing a piece of study content. Either [content]
 /// or [filePath] will be provided depending on how the content was
@@ -135,3 +136,6 @@ class ContentProvider extends ChangeNotifier {
     }
   }
 }
+
+/// Global provider exposing [ContentProvider] via Riverpod.
+final contentProvider = ChangeNotifierProvider<ContentProvider>((ref) => ContentProvider());

--- a/frontend/learn/lib/main.dart
+++ b/frontend/learn/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'constants.dart';
 import 'theme/app_theme.dart';
@@ -16,14 +17,12 @@ import 'screens/contextual_association_screen.dart';
 import 'screens/interactive_evaluation_screen.dart';
 import 'screens/progress_screen.dart';
 import 'screens/text_input_screen.dart';
-import 'package:provider/provider.dart';
 import 'content_provider.dart';
 
 void main() {
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => ContentProvider(),
-      child: const StudyApp(),
+    const ProviderScope(
+      child: StudyApp(),
     ),
   );
 }

--- a/frontend/learn/lib/screens/add_content_screen.dart
+++ b/frontend/learn/lib/screens/add_content_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
-import 'package:provider/provider.dart';
 import '../widgets/method_card.dart';
 import '../constants.dart';
-import '../content_provider.dart';
 
 /// Lists the available ways to add new study content.
 class AddContentScreen extends StatelessWidget {
@@ -11,8 +8,6 @@ class AddContentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final content = Provider.of<ContentProvider>(context, listen: false);
-
     return Scaffold(
       appBar: AppBar(title: const Text('Add Content')),
       body: Padding(

--- a/frontend/learn/lib/screens/analysis_screen.dart
+++ b/frontend/learn/lib/screens/analysis_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
@@ -7,12 +7,12 @@ import '../content_provider.dart';
 /// Presents the processed text to the user and allows them to choose
 /// their preferred study method. The text is scrollable and uses
 /// the current theme’s text styles.
-class AnalysisScreen extends StatelessWidget {
+class AnalysisScreen extends ConsumerWidget {
   const AnalysisScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = ref.watch(contentProvider);
     final summary = provider.summary ?? 'Summary will appear here.';
     final topics = provider.topics.isNotEmpty
         ? provider.topics.join(', ')

--- a/frontend/learn/lib/screens/audio_picker_screen.dart
+++ b/frontend/learn/lib/screens/audio_picker_screen.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:provider/provider.dart';
 
 import '../services/transcription_service.dart';
 
@@ -13,14 +13,14 @@ import '../widgets/primary_button.dart';
 
 /// Screen that lets the user pick an audio file, convert and transcribe it
 /// locally for analysis.
-class AudioPickerScreen extends StatefulWidget {
+class AudioPickerScreen extends ConsumerStatefulWidget {
   const AudioPickerScreen({super.key});
 
   @override
-  State<AudioPickerScreen> createState() => _AudioPickerScreenState();
+  ConsumerState<AudioPickerScreen> createState() => _AudioPickerScreenState();
 }
 
-class _AudioPickerScreenState extends State<AudioPickerScreen> {
+class _AudioPickerScreenState extends ConsumerState<AudioPickerScreen> {
   File? _selectedFile;
   bool _isProcessing = false;
   String? _transcript;
@@ -63,7 +63,7 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
         return;
       }
       if (!mounted) return;
-      context.read<ContentProvider>().setFileContent(
+      ref.read(contentProvider).setFileContent(
         path: _selectedFile!.path,
         content: transcription,
       );

--- a/frontend/learn/lib/screens/contextual_association_screen.dart
+++ b/frontend/learn/lib/screens/contextual_association_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
@@ -9,12 +9,12 @@ import '../widgets/key_value_card.dart';
 /// Encourages users to relate concepts to real‑world scenarios. Once
 /// complete, navigation continues to the progress screen using
 /// [Navigator.pushNamed].
-class ContextualAssociationScreen extends StatelessWidget {
+class ContextualAssociationScreen extends ConsumerWidget {
   const ContextualAssociationScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final exercises = context.watch<ContentProvider>().contextualExercises;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final exercises = ref.watch(contentProvider).contextualExercises;
     return Scaffold(
       appBar: AppBar(title: const Text('Contextual Association')),
       body: Padding(

--- a/frontend/learn/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learn/lib/screens/deep_understanding_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
@@ -11,12 +11,12 @@ import '../widgets/key_value_card.dart';
 /// navigate to the progress screen using a named route (not
 
 /// replacement) to preserve navigation history.
-class DeepUnderstandingScreen extends StatelessWidget {
+class DeepUnderstandingScreen extends ConsumerWidget {
   const DeepUnderstandingScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = ref.watch(contentProvider);
     final conceptMap = provider.conceptMap;
     final links = (conceptMap?['links'] as List?);
 

--- a/frontend/learn/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learn/lib/screens/interactive_evaluation_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../widgets/quiz_question_card.dart';
 import '../widgets/primary_button.dart';
@@ -10,12 +10,12 @@ import '../widgets/key_value_card.dart';
 /// Presents an interactive quiz. After submitting answers, the user can
 /// complete the session which navigates to the progress screen using
 /// [Navigator.pushNamed].
-class InteractiveEvaluationScreen extends StatelessWidget {
+class InteractiveEvaluationScreen extends ConsumerWidget {
   const InteractiveEvaluationScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final exercises = context.watch<ContentProvider>().evaluationQuestions;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final exercises = ref.watch(contentProvider).evaluationQuestions;
     return Scaffold(
       appBar: AppBar(title: const Text('Interactive Evaluation')),
       body: Padding(

--- a/frontend/learn/lib/screens/loading_screen.dart
+++ b/frontend/learn/lib/screens/loading_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../widgets/quote_card.dart';
 import '../constants.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../content_provider.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
@@ -11,18 +11,18 @@ import 'package:http/http.dart' as http;
 /// screen. We use [Navigator.pushNamed] here rather than
 /// [Navigator.pushReplacementNamed] so that the user can navigate
 /// back if desired.
-class LoadingScreen extends StatefulWidget {
+class LoadingScreen extends ConsumerStatefulWidget {
   const LoadingScreen({super.key});
 
   @override
-  State<LoadingScreen> createState() => _LoadingScreenState();
+  ConsumerState<LoadingScreen> createState() => _LoadingScreenState();
 }
 
-class _LoadingScreenState extends State<LoadingScreen> {
+class _LoadingScreenState extends ConsumerState<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    final provider = Provider.of<ContentProvider>(context, listen: false);
+    final provider = ref.read(contentProvider);
     if (provider.summary != null && provider.summary!.isNotEmpty) {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => Navigator.pushNamed(context, Routes.analysis),
@@ -33,7 +33,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
   }
 
   Future<void> _analyze() async {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
+    final provider = ref.read(contentProvider);
     try {
       final url = Uri.parse('http://10.0.2.2:8000/analyze');
       final response = await http.post(

--- a/frontend/learn/lib/screens/memorization_screen.dart
+++ b/frontend/learn/lib/screens/memorization_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../widgets/flashcard_widget.dart';
 import '../widgets/primary_button.dart';
@@ -9,12 +9,12 @@ import '../content_provider.dart';
 /// Presents flashcard‑style activities for memorization. Buttons for
 /// grading difficulty are included. Completion navigates to the
 /// progress screen via [Navigator.pushNamed].
-class MemorizationScreen extends StatelessWidget {
+class MemorizationScreen extends ConsumerWidget {
   const MemorizationScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final cards = context.watch<ContentProvider>().flashcards;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cards = ref.watch(contentProvider).flashcards;
     return Scaffold(
       appBar: AppBar(title: const Text('Memorization')),
       body: Padding(

--- a/frontend/learn/lib/screens/method_selection_screen.dart
+++ b/frontend/learn/lib/screens/method_selection_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../widgets/method_card.dart';
 import '../constants.dart';
@@ -7,12 +7,12 @@ import '../content_provider.dart';
 
 /// Lists the available study methods. Each card navigates to its
 /// corresponding screen using a named route.
-class MethodSelectionScreen extends StatelessWidget {
+class MethodSelectionScreen extends ConsumerWidget {
   const MethodSelectionScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final summaries = context.watch<ContentProvider>().activitySummaries;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaries = ref.watch(contentProvider).activitySummaries;
     return Scaffold(
       appBar: AppBar(title: const Text('Study Methods')),
       body: Padding(

--- a/frontend/learn/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learn/lib/screens/pdf_picker_screen.dart
@@ -2,22 +2,22 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:syncfusion_flutter_pdf/pdf.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pdf_text/pdf_text.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 
 /// Allows the user to pick a PDF file and extract its text locally.
-class PdfPickerScreen extends StatefulWidget {
+class PdfPickerScreen extends ConsumerStatefulWidget {
   const PdfPickerScreen({super.key});
 
   @override
-  State<PdfPickerScreen> createState() => _PdfPickerScreenState();
+  ConsumerState<PdfPickerScreen> createState() => _PdfPickerScreenState();
 }
 
-class _PdfPickerScreenState extends State<PdfPickerScreen> {
+class _PdfPickerScreenState extends ConsumerState<PdfPickerScreen> {
   File? _file;
   String? _text;
   bool _isProcessing = false;
@@ -42,12 +42,10 @@ class _PdfPickerScreenState extends State<PdfPickerScreen> {
     });
 
     try {
-      final bytes = await _file!.readAsBytes();
-      final document = PdfDocument(inputBytes: bytes);
-      final extracted = PdfTextExtractor(document).extractText();
-      document.dispose();
+      final doc = await PDFDoc.fromFile(_file!);
+      final extracted = await doc.text;
       if (!mounted) return;
-      context.read<ContentProvider>().setFileContent(
+      ref.read(contentProvider).setFileContent(
         path: _file!.path,
         content: extracted,
       );

--- a/frontend/learn/lib/screens/progress_screen.dart
+++ b/frontend/learn/lib/screens/progress_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../content_provider.dart';
 import '../widgets/progress_summary_card.dart';
@@ -8,18 +8,17 @@ import '../widgets/quote_card.dart';
 /// Displays summary statistics for the user’s progress. Navigation back
 /// to the home page is provided by the bottom navigation bar, so we
 /// simply show a motivational quote instead of a button.
-class ProgressScreen extends StatelessWidget {
+class ProgressScreen extends ConsumerWidget {
   const ProgressScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = ref.watch(contentProvider);
+    final progress = provider.progress;
     return Scaffold(
       appBar: AppBar(title: const Text('Progress')),
-      body: Consumer<ContentProvider>(
-        builder: (context, provider, _) {
-          final progress = provider.progress;
-          if (progress.isEmpty) {
-            return Center(
+      body: progress.isEmpty
+          ? Center(
               child: Text(
                 'Could not load progress',
                 style: Theme.of(context)
@@ -27,28 +26,25 @@ class ProgressScreen extends StatelessWidget {
                     .bodyLarge
                     ?.copyWith(color: Colors.white70),
               ),
-            );
-          }
-          final entries = progress.entries.toList();
-          return Padding(
-            padding: const EdgeInsets.all(20.0),
-            child: ListView.separated(
-              itemCount: entries.length + 1,
-              separatorBuilder: (context, index) => const SizedBox(height: 16),
-              itemBuilder: (context, index) {
-                if (index == entries.length) {
-                  return const QuoteCard(quote: 'Keep up the great work!');
-                }
-                final entry = entries[index];
-                return ProgressSummaryCard(
-                  title: entry.key,
-                  value: entry.value.toString(),
-                );
-              },
+            )
+          : Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: ListView.separated(
+                itemCount: progress.length + 1,
+                separatorBuilder: (context, index) =>
+                    const SizedBox(height: 16),
+                itemBuilder: (context, index) {
+                  if (index == progress.length) {
+                    return const QuoteCard(quote: 'Keep up the great work!');
+                  }
+                  final entry = progress.entries.elementAt(index);
+                  return ProgressSummaryCard(
+                    title: entry.key,
+                    value: entry.value.toString(),
+                  );
+                },
+              ),
             ),
-          );
-        },
-      ),
     );
   }
 }

--- a/frontend/learn/lib/screens/projects_screen.dart
+++ b/frontend/learn/lib/screens/projects_screen.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../content_provider.dart';
 import '../theme/app_theme.dart';
 
 /// Displays the list of saved study content. Replaces the old
 /// [LibraryScreen] which was an empty placeholder.
-class ProjectsScreen extends StatelessWidget {
+class ProjectsScreen extends ConsumerWidget {
   const ProjectsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final provider = ref.watch(contentProvider);
     final items = provider.savedContent;
     return Scaffold(
       appBar: AppBar(title: const Text('Library')),

--- a/frontend/learn/lib/screens/text_input_screen.dart
+++ b/frontend/learn/lib/screens/text_input_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/primary_button.dart';
 import '../theme/app_theme.dart';
 import '../constants.dart';
@@ -9,14 +9,14 @@ import '../content_provider.dart';
 /// Provides a multiline text field for users to paste or type text.
 /// After continuing a short loading screen is shown before
 /// navigating to the analysis stage.
-class TextInputScreen extends StatefulWidget {
+class TextInputScreen extends ConsumerStatefulWidget {
   const TextInputScreen({super.key});
 
   @override
-  State<TextInputScreen> createState() => _TextInputScreenState();
+  ConsumerState<TextInputScreen> createState() => _TextInputScreenState();
 }
 
-class _TextInputScreenState extends State<TextInputScreen> {
+class _TextInputScreenState extends ConsumerState<TextInputScreen> {
   final TextEditingController _controller = TextEditingController();
 
   @override
@@ -28,7 +28,7 @@ class _TextInputScreenState extends State<TextInputScreen> {
   // After tapping Continue we store the text and show a loading screen
   // before navigating to analysis.
   Future<void> _onContinuePressed() async {
-    final provider = Provider.of<ContentProvider>(context, listen: false);
+    final provider = ref.read(contentProvider);
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     provider.setContent(text);

--- a/frontend/learn/lib/screens/video_picker_screen.dart
+++ b/frontend/learn/lib/screens/video_picker_screen.dart
@@ -2,21 +2,21 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 import '../services/transcription_service.dart';
 
 /// Picks a video file, extracts the audio track, and transcribes it locally.
-class VideoPickerScreen extends StatefulWidget {
+class VideoPickerScreen extends ConsumerStatefulWidget {
   const VideoPickerScreen({super.key});
 
   @override
-  State<VideoPickerScreen> createState() => _VideoPickerScreenState();
+  ConsumerState<VideoPickerScreen> createState() => _VideoPickerScreenState();
 }
 
-class _VideoPickerScreenState extends State<VideoPickerScreen> {
+class _VideoPickerScreenState extends ConsumerState<VideoPickerScreen> {
   File? _videoFile;
   bool _isProcessing = false;
   String? _transcript;
@@ -55,7 +55,7 @@ class _VideoPickerScreenState extends State<VideoPickerScreen> {
         return;
       }
       if (!mounted) return;
-      context.read<ContentProvider>().setFileContent(
+      ref.read(contentProvider).setFileContent(
         path: _videoFile!.path,
         content: text,
       );

--- a/frontend/learn/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/learn/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,7 @@ import ffmpeg_kit_flutter_min_gpl
 import file_picker
 import just_audio
 import path_provider_foundation
-import speech_to_text_macos
+import whisper_flutter
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
@@ -18,5 +18,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  SpeechToTextMacosPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextMacosPlugin"))
+  WhisperFlutterPlugin.register(with: registry.registrar(forPlugin: "WhisperFlutterPlugin"))
 }

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -34,17 +34,18 @@ dependencies:
 
   # Allows picking local files for the mocked upload flow.
   file_picker: ^10.2.0
-  provider: ^6.1.1
-  http: ^1.4.0
+  file_selector: ^1.0.0
+  flutter_riverpod: ^2.5.1
+  http: ^1.2.1
   permission_handler: ^11.3.0
-  syncfusion_flutter_pdf: ^27.1.58
   ffmpeg_kit_flutter_min_gpl: ^6.0.0
-  speech_to_text: ^6.5.1
+  just_audio: ^0.9.36
+  pdf_text: ^0.9.0
+  whisper_flutter: ^0.6.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  just_audio: ^0.9.36
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace Provider with Riverpod and expose a `contentProvider`
- swap Syncfusion PDF for `pdf_text` and update PDF picker
- move audio transcription to `whisper_flutter`
- add recommended packages and clean up plugin registrant

## Testing
- `flutter pub upgrade --major-versions` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a522643a608329976f0248ec15c5a4