### PR TITLE
chore: update AGP and Kotlin versions

### DIFF
--- a/frontend/learn/android/gradle/wrapper/gradle-wrapper.properties
+++ b/frontend/learn/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/frontend/learn/android/settings.gradle.kts
+++ b/frontend/learn/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.3.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- use Android Gradle Plugin 8.3.0
- use Kotlin 1.9.0
- align wrapper to Gradle 8.4

## Testing
- `gradle help --console=plain --no-daemon` *(fails: `/workspace/LearnSynth/frontend/learn/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_68a52421df4083299660c0db7673f5b9