### PR TITLE
refactor: replace riverpod with provider

### DIFF
--- a/frontend/learn/lib/content_provider.dart
+++ b/frontend/learn/lib/content_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Simple model representing a piece of study content. Either [content]
 /// or [filePath] will be provided depending on how the content was
@@ -137,5 +136,3 @@ class ContentProvider extends ChangeNotifier {
   }
 }
 
-/// Global provider exposing [ContentProvider] via Riverpod.
-final contentProvider = ChangeNotifierProvider<ContentProvider>((ref) => ContentProvider());

--- a/frontend/learn/lib/main.dart
+++ b/frontend/learn/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import 'constants.dart';
 import 'theme/app_theme.dart';
@@ -20,7 +20,12 @@ import 'screens/text_input_screen.dart';
 import 'content_provider.dart';
 
 void main() {
-  runApp(ProviderScope(child: StudyApp()));
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => ContentProvider(),
+      child: const StudyApp(),
+    ),
+  );
 }
 
 class StudyApp extends StatelessWidget {

--- a/frontend/learn/lib/screens/analysis_screen.dart
+++ b/frontend/learn/lib/screens/analysis_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
@@ -7,12 +7,12 @@ import '../content_provider.dart';
 /// Presents the processed text to the user and allows them to choose
 /// their preferred study method. The text is scrollable and uses
 /// the current theme’s text styles.
-class AnalysisScreen extends ConsumerWidget {
+class AnalysisScreen extends StatelessWidget {
   const AnalysisScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(contentProvider);
+  Widget build(BuildContext context) {
+    final provider = context.watch<ContentProvider>();
     final summary = provider.summary ?? 'Summary will appear here.';
     final topics = provider.topics.isNotEmpty
         ? provider.topics.join(', ')

--- a/frontend/learn/lib/screens/audio_picker_screen.dart
+++ b/frontend/learn/lib/screens/audio_picker_screen.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../services/transcription_service.dart';
@@ -13,14 +13,14 @@ import '../widgets/primary_button.dart';
 
 /// Screen that lets the user pick an audio file, convert and transcribe it
 /// locally for analysis.
-class AudioPickerScreen extends ConsumerStatefulWidget {
+class AudioPickerScreen extends StatefulWidget {
   const AudioPickerScreen({super.key});
 
   @override
-  ConsumerState<AudioPickerScreen> createState() => _AudioPickerScreenState();
+  State<AudioPickerScreen> createState() => _AudioPickerScreenState();
 }
 
-class _AudioPickerScreenState extends ConsumerState<AudioPickerScreen> {
+class _AudioPickerScreenState extends State<AudioPickerScreen> {
   File? _selectedFile;
   bool _isProcessing = false;
   String? _transcript;
@@ -63,7 +63,7 @@ class _AudioPickerScreenState extends ConsumerState<AudioPickerScreen> {
         return;
       }
       if (!mounted) return;
-      ref.read(contentProvider).setFileContent(
+      context.read<ContentProvider>().setFileContent(
         path: _selectedFile!.path,
         content: transcription,
       );

--- a/frontend/learn/lib/screens/contextual_association_screen.dart
+++ b/frontend/learn/lib/screens/contextual_association_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
@@ -9,12 +9,12 @@ import '../widgets/key_value_card.dart';
 /// Encourages users to relate concepts to real‑world scenarios. Once
 /// complete, navigation continues to the progress screen using
 /// [Navigator.pushNamed].
-class ContextualAssociationScreen extends ConsumerWidget {
+class ContextualAssociationScreen extends StatelessWidget {
   const ContextualAssociationScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final exercises = ref.watch(contentProvider).contextualExercises;
+  Widget build(BuildContext context) {
+    final exercises = context.watch<ContentProvider>().contextualExercises;
     return Scaffold(
       appBar: AppBar(title: const Text('Contextual Association')),
       body: Padding(

--- a/frontend/learn/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learn/lib/screens/deep_understanding_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
@@ -11,12 +11,12 @@ import '../widgets/key_value_card.dart';
 /// navigate to the progress screen using a named route (not
 
 /// replacement) to preserve navigation history.
-class DeepUnderstandingScreen extends ConsumerWidget {
+class DeepUnderstandingScreen extends StatelessWidget {
   const DeepUnderstandingScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(contentProvider);
+  Widget build(BuildContext context) {
+    final provider = context.watch<ContentProvider>();
     final conceptMap = provider.conceptMap;
     final links = (conceptMap?['links'] as List?);
 

--- a/frontend/learn/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learn/lib/screens/interactive_evaluation_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../widgets/quiz_question_card.dart';
 import '../widgets/primary_button.dart';
@@ -10,12 +10,13 @@ import '../widgets/key_value_card.dart';
 /// Presents an interactive quiz. After submitting answers, the user can
 /// complete the session which navigates to the progress screen using
 /// [Navigator.pushNamed].
-class InteractiveEvaluationScreen extends ConsumerWidget {
+class InteractiveEvaluationScreen extends StatelessWidget {
   const InteractiveEvaluationScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final exercises = ref.watch(contentProvider).evaluationQuestions;
+  Widget build(BuildContext context) {
+    final exercises =
+        context.watch<ContentProvider>().evaluationQuestions;
     return Scaffold(
       appBar: AppBar(title: const Text('Interactive Evaluation')),
       body: Padding(

--- a/frontend/learn/lib/screens/loading_screen.dart
+++ b/frontend/learn/lib/screens/loading_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../widgets/quote_card.dart';
 import '../constants.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import '../content_provider.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
@@ -11,18 +11,18 @@ import 'package:http/http.dart' as http;
 /// screen. We use [Navigator.pushNamed] here rather than
 /// [Navigator.pushReplacementNamed] so that the user can navigate
 /// back if desired.
-class LoadingScreen extends ConsumerStatefulWidget {
+class LoadingScreen extends StatefulWidget {
   const LoadingScreen({super.key});
 
   @override
-  ConsumerState<LoadingScreen> createState() => _LoadingScreenState();
+  State<LoadingScreen> createState() => _LoadingScreenState();
 }
 
-class _LoadingScreenState extends ConsumerState<LoadingScreen> {
+class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-    final provider = ref.read(contentProvider);
+    final provider = context.read<ContentProvider>();
     if (provider.summary != null && provider.summary!.isNotEmpty) {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => Navigator.pushNamed(context, Routes.analysis),
@@ -33,7 +33,7 @@ class _LoadingScreenState extends ConsumerState<LoadingScreen> {
   }
 
   Future<void> _analyze() async {
-    final provider = ref.read(contentProvider);
+    final provider = context.read<ContentProvider>();
     try {
       final url = Uri.parse('http://10.0.2.2:8000/analyze');
       final response = await http.post(

--- a/frontend/learn/lib/screens/memorization_screen.dart
+++ b/frontend/learn/lib/screens/memorization_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../widgets/flashcard_widget.dart';
 import '../widgets/primary_button.dart';
@@ -9,12 +9,12 @@ import '../content_provider.dart';
 /// Presents flashcard‑style activities for memorization. Buttons for
 /// grading difficulty are included. Completion navigates to the
 /// progress screen via [Navigator.pushNamed].
-class MemorizationScreen extends ConsumerWidget {
+class MemorizationScreen extends StatelessWidget {
   const MemorizationScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final cards = ref.watch(contentProvider).flashcards;
+  Widget build(BuildContext context) {
+    final cards = context.watch<ContentProvider>().flashcards;
     return Scaffold(
       appBar: AppBar(title: const Text('Memorization')),
       body: Padding(

--- a/frontend/learn/lib/screens/method_selection_screen.dart
+++ b/frontend/learn/lib/screens/method_selection_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../widgets/method_card.dart';
 import '../constants.dart';
@@ -7,12 +7,12 @@ import '../content_provider.dart';
 
 /// Lists the available study methods. Each card navigates to its
 /// corresponding screen using a named route.
-class MethodSelectionScreen extends ConsumerWidget {
+class MethodSelectionScreen extends StatelessWidget {
   const MethodSelectionScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final summaries = ref.watch(contentProvider).activitySummaries;
+  Widget build(BuildContext context) {
+    final summaries = context.watch<ContentProvider>().activitySummaries;
     return Scaffold(
       appBar: AppBar(title: const Text('Study Methods')),
       body: Padding(

--- a/frontend/learn/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learn/lib/screens/pdf_picker_screen.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import 'package:pdf_text/pdf_text.dart';
 
 import '../widgets/primary_button.dart';
@@ -10,14 +10,14 @@ import '../constants.dart';
 import '../content_provider.dart';
 
 /// Allows the user to pick a PDF file and extract its text locally.
-class PdfPickerScreen extends ConsumerStatefulWidget {
+class PdfPickerScreen extends StatefulWidget {
   const PdfPickerScreen({super.key});
 
   @override
-  ConsumerState<PdfPickerScreen> createState() => _PdfPickerScreenState();
+  State<PdfPickerScreen> createState() => _PdfPickerScreenState();
 }
 
-class _PdfPickerScreenState extends ConsumerState<PdfPickerScreen> {
+class _PdfPickerScreenState extends State<PdfPickerScreen> {
   File? _file;
   String? _text;
   bool _isProcessing = false;
@@ -45,7 +45,7 @@ class _PdfPickerScreenState extends ConsumerState<PdfPickerScreen> {
       final doc = await PDFDoc.fromFile(_file!);
       final extracted = await doc.text;
       if (!mounted) return;
-      ref.read(contentProvider).setFileContent(
+      context.read<ContentProvider>().setFileContent(
         path: _file!.path,
         content: extracted,
       );

--- a/frontend/learn/lib/screens/progress_screen.dart
+++ b/frontend/learn/lib/screens/progress_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 
 import '../content_provider.dart';
 import '../widgets/progress_summary_card.dart';
@@ -8,12 +8,12 @@ import '../widgets/quote_card.dart';
 /// Displays summary statistics for the user’s progress. Navigation back
 /// to the home page is provided by the bottom navigation bar, so we
 /// simply show a motivational quote instead of a button.
-class ProgressScreen extends ConsumerWidget {
+class ProgressScreen extends StatelessWidget {
   const ProgressScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(contentProvider);
+  Widget build(BuildContext context) {
+    final provider = context.watch<ContentProvider>();
     final progress = provider.progress;
     return Scaffold(
       appBar: AppBar(title: const Text('Progress')),

--- a/frontend/learn/lib/screens/projects_screen.dart
+++ b/frontend/learn/lib/screens/projects_screen.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import '../content_provider.dart';
 import '../theme/app_theme.dart';
 
 /// Displays the list of saved study content. Replaces the old
 /// [LibraryScreen] which was an empty placeholder.
-class ProjectsScreen extends ConsumerWidget {
+class ProjectsScreen extends StatelessWidget {
   const ProjectsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final provider = ref.watch(contentProvider);
+  Widget build(BuildContext context) {
+    final provider = context.watch<ContentProvider>();
     final items = provider.savedContent;
     return Scaffold(
       appBar: AppBar(title: const Text('Library')),

--- a/frontend/learn/lib/screens/text_input_screen.dart
+++ b/frontend/learn/lib/screens/text_input_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
 import '../theme/app_theme.dart';
 import '../constants.dart';
@@ -9,14 +9,14 @@ import '../content_provider.dart';
 /// Provides a multiline text field for users to paste or type text.
 /// After continuing a short loading screen is shown before
 /// navigating to the analysis stage.
-class TextInputScreen extends ConsumerStatefulWidget {
+class TextInputScreen extends StatefulWidget {
   const TextInputScreen({super.key});
 
   @override
-  ConsumerState<TextInputScreen> createState() => _TextInputScreenState();
+  State<TextInputScreen> createState() => _TextInputScreenState();
 }
 
-class _TextInputScreenState extends ConsumerState<TextInputScreen> {
+class _TextInputScreenState extends State<TextInputScreen> {
   final TextEditingController _controller = TextEditingController();
 
   @override
@@ -28,7 +28,7 @@ class _TextInputScreenState extends ConsumerState<TextInputScreen> {
   // After tapping Continue we store the text and show a loading screen
   // before navigating to analysis.
   Future<void> _onContinuePressed() async {
-    final provider = ref.read(contentProvider);
+    final provider = context.read<ContentProvider>();
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     provider.setContent(text);

--- a/frontend/learn/lib/screens/video_picker_screen.dart
+++ b/frontend/learn/lib/screens/video_picker_screen.dart
@@ -2,21 +2,21 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 import '../services/transcription_service.dart';
 
 /// Picks a video file, extracts the audio track, and transcribes it locally.
-class VideoPickerScreen extends ConsumerStatefulWidget {
+class VideoPickerScreen extends StatefulWidget {
   const VideoPickerScreen({super.key});
 
   @override
-  ConsumerState<VideoPickerScreen> createState() => _VideoPickerScreenState();
+  State<VideoPickerScreen> createState() => _VideoPickerScreenState();
 }
 
-class _VideoPickerScreenState extends ConsumerState<VideoPickerScreen> {
+class _VideoPickerScreenState extends State<VideoPickerScreen> {
   File? _videoFile;
   bool _isProcessing = false;
   String? _transcript;
@@ -55,7 +55,7 @@ class _VideoPickerScreenState extends ConsumerState<VideoPickerScreen> {
         return;
       }
       if (!mounted) return;
-      ref.read(contentProvider).setFileContent(
+      context.read<ContentProvider>().setFileContent(
         path: _videoFile!.path,
         content: text,
       );

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # Allows picking local files for the mocked upload flow.
   file_picker: ^10.2.0
   file_selector: ^1.0.0
-  flutter_riverpod: ^2.6.1
+  provider: ^6.1.0
   http: ^1.2.1
   permission_handler: ^11.3.0
   ffmpeg_kit_flutter_min_gpl: ^6.0.0


### PR DESCRIPTION
## Summary
- replace Riverpod with Provider for state management
- wrap app with ChangeNotifierProvider and update widgets to use context.read/watch
- remove riverpod dependency and global provider declaration

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a52b635e68832982a4437f5b3510c1