### PR TITLE
feat: switch transcription to vosk

### DIFF
--- a/frontend/learn/lib/services/transcription_service.dart
+++ b/frontend/learn/lib/services/transcription_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
-import 'package:whisper_flutter/whisper_flutter.dart';
+import 'package:vosk_flutter/vosk_flutter.dart';
 
 /// A simple wrapper that mimics an FFmpeg session result.
 class FfmpegResult<T> {
@@ -16,7 +16,11 @@ class FfmpegResult<T> {
 
 /// Provides audio transcription utilities backed by on-device processing.
 class TranscriptionService {
-  final Whisper _whisper = Whisper();
+  final VoskFlutter _vosk = VoskFlutter();
+
+  TranscriptionService() {
+    unawaited(_vosk.init(modelPath: 'assets/models/vosk-model-small'));
+  }
 
   /// Extracts the audio track from a [videoFile] and stores it as a WAV file.
   ///
@@ -42,12 +46,12 @@ class TranscriptionService {
 
   /// Transcribes the given [audioFile] and returns the recognized text.
   ///
-  /// The transcription is performed on-device using the platform speech
-  /// recognizer. A [FfmpegResult] containing the transcription text is returned
+  /// The transcription is performed on-device using the Vosk speech recognition
+  /// engine. A [FfmpegResult] containing the transcription text is returned
   /// on success, otherwise the [data] is `null` and [returnCode] is non-zero.
   Future<FfmpegResult<String>> transcribeAudio(File audioFile) async {
     try {
-      final transcript = await _whisper.convertFileToText(audioFile.path);
+      final transcript = await _vosk.recognize(audioFile.path);
       if (transcript.trim().isEmpty) {
         return const FfmpegResult<String>(data: null, returnCode: 1);
       }

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   ffmpeg_kit_flutter_min_gpl: ^6.0.0
   just_audio: ^0.9.36
   pdf_text: ^0.9.0
-  flutter_whisper: ^0.3.1
+  vosk_flutter: ^1.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -68,6 +68,9 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+
+  assets:
+    - assets/models/vosk-model-small/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- use Vosk for on-device transcription
- add Vosk model assets and dependency

## Testing
- `dart format frontend/learn/lib/services/transcription_service.dart frontend/learn/pubspec.yaml` (fails: command not found)
- `flutter pub get` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a52b986654832987b04e57d89948b5