### PR TITLE
refactor: use file_selector for file picking

### DIFF
--- a/frontend/learn/lib/screens/audio_picker_screen.dart
+++ b/frontend/learn/lib/screens/audio_picker_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -34,15 +34,16 @@ class _AudioPickerScreenState extends State<AudioPickerScreen> {
         }
       }
 
-      final result = await FilePicker.platform.pickFiles(
-        type: FileType.custom,
-        allowedExtensions: ['mp3', 'wav', 'm4a'],
+      final XFile? result = await openFile(
+        acceptedTypeGroups: [
+          XTypeGroup(label: 'audio', extensions: ['mp3', 'wav', 'm4a']),
+        ],
       );
-      if (result == null || result.files.single.path == null) {
+      if (result == null) {
         _showError('No file selected.');
         return;
       }
-      _selectedFile = File(result.files.single.path!);
+      _selectedFile = File(result.path);
       setState(() {
         _isProcessing = true;
         _transcript = null;

--- a/frontend/learn/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learn/lib/screens/pdf_picker_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pdf_text/pdf_text.dart';
@@ -23,19 +23,20 @@ class _PdfPickerScreenState extends State<PdfPickerScreen> {
   bool _isProcessing = false;
 
   Future<void> _pickPdf() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['pdf'],
+    final XFile? result = await openFile(
+      acceptedTypeGroups: [
+        XTypeGroup(label: 'pdf', extensions: ['pdf']),
+      ],
     );
     if (!mounted) return;
-    if (result == null || result.files.single.path == null) {
+    if (result == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('No file selected')),
       );
       return;
     }
 
-    _file = File(result.files.single.path!);
+    _file = File(result.path);
     setState(() {
       _isProcessing = true;
       _text = null;

--- a/frontend/learn/lib/screens/video_picker_screen.dart
+++ b/frontend/learn/lib/screens/video_picker_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../widgets/primary_button.dart';
@@ -22,12 +22,16 @@ class _VideoPickerScreenState extends State<VideoPickerScreen> {
   String? _transcript;
 
   Future<void> _pickVideo() async {
-    final result = await FilePicker.platform.pickFiles(type: FileType.video);
-    if (result == null || result.files.single.path == null) {
+    final XFile? result = await openFile(
+      acceptedTypeGroups: [
+        XTypeGroup(label: 'video', mimeTypes: ['video/*']),
+      ],
+    );
+    if (result == null) {
       _showError('No file selected.');
       return;
     }
-    _videoFile = File(result.files.single.path!);
+    _videoFile = File(result.path);
     setState(() {
       _isProcessing = true;
       _transcript = null;

--- a/frontend/learn/pubspec.lock
+++ b/frontend/learn/pubspec.lock
@@ -129,14 +129,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
-  file_picker:
-    dependency: "direct main"
-    description:
-      name: file_picker
-      sha256: ef7d2a085c1b1d69d17b6842d0734aad90156de08df6bd3c12496d0bd6ddf8e2
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.3.1"
   fixnum:
     dependency: transitive
     description:

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
     sdk: flutter
 
   # Allows picking local files for the mocked upload flow.
-  file_picker: ^10.2.0
   file_selector: ^1.0.0
   provider: ^6.1.0
   http: ^1.2.1


### PR DESCRIPTION
## Summary
- remove file_picker dependency
- use file_selector across PDF, audio, and video screens

## Testing
- `dart format lib/screens/pdf_picker_screen.dart lib/screens/audio_picker_screen.dart lib/screens/video_picker_screen.dart` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53ef7e2648329919f89313db90254