### PR TITLE
Replace deprecated dependencies with supported equivalents

### DIFF
--- a/frontend/learn/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learn/lib/screens/pdf_picker_screen.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:pdf_text/pdf_text.dart';
+import 'package:pdfx/pdfx.dart';
 
 import '../widgets/primary_button.dart';
 import '../constants.dart';
@@ -43,8 +43,15 @@ class _PdfPickerScreenState extends State<PdfPickerScreen> {
     });
 
     try {
-      final doc = await PDFDoc.fromFile(_file!);
-      final extracted = await doc.text;
+      final document = await PdfDocument.openFile(_file!.path);
+      String extracted = '';
+      for (var i = 1; i <= document.pagesCount; i++) {
+        final page = await document.getPage(i);
+        final text = await page.getText();
+        extracted += text?.text ?? '';
+        await page.close();
+      }
+      await document.close();
       if (!mounted) return;
       context.read<ContentProvider>().setFileContent(
         path: _file!.path,

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -32,18 +32,14 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # Allows picking local files for the mocked upload flow.
-  file_selector: ^1.0.0
   provider: ^6.1.0
   http: ^1.2.1
   permission_handler: ^11.3.0
   ffmpeg_kit_flutter_min_gpl: ^6.0.0
   just_audio: ^0.9.36
-  pdf_text: ^0.9.0
-  vosk_flutter: ^1.0.0
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
+  file_selector: ^1.0.3
+  speech_to_text: ^6.6.2
+  pdfx: ^2.6.0
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
@@ -67,9 +63,6 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
-
-  assets:
-    - assets/models/vosk-model-small/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- replace deprecated `vosk_flutter` and `pdf_text` with `speech_to_text` and `pdfx`
- update `TranscriptionService` to use `SpeechToText`
- swap out PDF text extraction to use `pdfx`
- refresh pubspec dependencies (including `file_selector` v1.0.3)

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `dart format lib/services/transcription_service.dart lib/screens/pdf_picker_screen.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68a544632e6c8329b94cf8f6da0ac870