### PR TITLE
Replace pdfx with native_pdf_renderer dependency

### DIFF
--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   just_audio: ^0.9.36
   file_selector: ^1.0.3
   speech_to_text: ^6.6.2
-  pdfx: ^2.6.0
+  native_pdf_renderer: ^6.0.0
   cupertino_icons: ^1.0.8
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- swap pdfx dependency for native_pdf_renderer in Flutter frontend

## Testing
- `flutter pub get` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a547bd14188329a37b9d377042e1b0