### PR TITLE
Add namespace to flutter_ffmpeg Android build file

### DIFF
--- a/frontend/learn/pub-cache/hosted/pub.dev/flutter_ffmpeg-0.4.2/android/build.gradle
+++ b/frontend/learn/pub-cache/hosted/pub.dev/flutter_ffmpeg-0.4.2/android/build.gradle
@@ -1,0 +1,4 @@
+android {
+    namespace "com.arthenica.flutter.ffmpeg"
+    compileSdkVersion 30
+}


### PR DESCRIPTION
## Summary
- Specify `com.arthenica.flutter.ffmpeg` namespace in flutter_ffmpeg plugin build.gradle to satisfy Android's namespace requirement

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a55a2471488329af828816da319b10