### PR TITLE
Replace SpeechToText with Vosk transcription

### DIFF
--- a/frontend/learn/lib/services/transcription_service.dart
+++ b/frontend/learn/lib/services/transcription_service.dart
@@ -1,79 +1,56 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_sound/flutter_sound.dart';
-import 'package:speech_to_text/speech_to_text.dart';
+import 'package:vosk_flutter/vosk_flutter.dart';
 
-/// Simple wrapper that mimics an FFmpeg session result.
-class FfmpegResult<T> {
-  final T? data;
-  final int returnCode;
-
-  const FfmpegResult({this.data, required this.returnCode});
-
-  bool get isSuccess => returnCode == 0;
-}
-
-/// Provides audio transcription utilities backed by on-device processing.
+/// Provides audio transcription utilities backed by the Vosk speech
+/// recognition engine.
 class TranscriptionService {
-  final SpeechToText _speech = SpeechToText();
   final FlutterSoundHelper _soundHelper = FlutterSoundHelper();
 
-  /// Extracts the audio track from [videoFile] and stores it as a WAV file.
+  /// Transcribes the given [file] and returns the recognized text.
   ///
-  /// Returns a [FfmpegResult] whose [data] contains the generated audio file on
-  /// success or `null` on failure. `returnCode` is 0 on success, 1 on error.
-  Future<FfmpegResult<File>> extractAudioFromVideo(File videoFile) async {
-    final outputPath =
-        '${videoFile.path}_${DateTime.now().millisecondsSinceEpoch}.wav';
+  /// Video files have their audio track extracted before being processed.
+  Future<String> transcribeFile(File file) async {
+    File audioFile = file;
 
-    try {
+    final extension = file.path.split('.').last.toLowerCase();
+    if (_videoExtensions.contains(extension)) {
+      final outputPath =
+          '${file.path}_${DateTime.now().millisecondsSinceEpoch}.wav';
       await _soundHelper.convertFile(
-        inputFile: videoFile.path,
+        inputFile: file.path,
         outputFile: outputPath,
         codec: Codec.pcm16WAV,
         sampleRate: 16_000,
         numChannels: 1,
       );
-      return FfmpegResult<File>(data: File(outputPath), returnCode: 0);
-    } catch (_) {
-      return const FfmpegResult<File>(data: null, returnCode: 1);
+      audioFile = File(outputPath);
     }
+
+    final bytes = await audioFile.readAsBytes();
+
+    final model = await Model.fromAsset('assets/vosk/model');
+    final recognizer = Recognizer(model: model, sampleRate: 16_000);
+
+    recognizer.acceptWaveform(bytes);
+    final result = recognizer.finalResult();
+
+    recognizer.close();
+    model.close();
+
+    if (audioFile.path != file.path) {
+      await audioFile.delete();
+    }
+
+    return result;
   }
 
-  /// Transcribes the given [audioFile] and returns the recognized text.
-  ///
-  /// The transcription is performed using the [SpeechToText] plugin, which
-  /// listens to the microphone and returns the recognized text.
-  ///
-  /// The provided [audioFile] parameter is ignored as `speech_to_text` does not
-  /// support transcribing from pre‑recorded files directly.
-  Future<FfmpegResult<String>> transcribeAudio(File audioFile) async {
-    try {
-      final available = await _speech.initialize();
-      if (!available) {
-        return const FfmpegResult<String>(data: null, returnCode: 1);
-      }
-
-      final completer = Completer<String>();
-      _speech.listen(
-        onResult: (result) {
-          if (result.finalResult) {
-            completer.complete(result.recognizedWords);
-          }
-        },
-      );
-
-      final transcript = await completer.future;
-      await _speech.stop();
-
-      if (transcript.trim().isEmpty) {
-        return const FfmpegResult<String>(data: null, returnCode: 1);
-      }
-
-      return FfmpegResult<String>(data: transcript, returnCode: 0);
-    } catch (_) {
-      return const FfmpegResult<String>(data: null, returnCode: 1);
-    }
-  }
+  static const Set<String> _videoExtensions = {
+    'mp4',
+    'mov',
+    'avi',
+    'mkv',
+  };
 }
+

--- a/frontend/learn/pubspec.yaml
+++ b/frontend/learn/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   flutter_sound: ^9.2.13  # lightweight converter/recorder
   just_audio: ^0.9.36
   file_selector: ^1.0.3
-  speech_to_text: ^6.6.2
+  vosk_flutter: ^0.3.38
   syncfusion_flutter_pdf: ^27.1.57
   cupertino_icons: ^1.0.8
 


### PR DESCRIPTION
## Summary
- swap SpeechToText-based transcription for Vosk Model/Recognizer
- support audio extraction from videos via FlutterSoundHelper
- update dependencies to use `vosk_flutter`

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format frontend/learn/lib/services/transcription_service.dart frontend/learn/pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a56898b9e8832984c69cf225962fab