### PR TITLE
Handle uploads by extension and simplify file picker

### DIFF
--- a/frontend/learns/lib/screens/audio_picker_screen.dart
+++ b/frontend/learns/lib/screens/audio_picker_screen.dart
@@ -10,7 +10,10 @@ class AudioPickerScreen extends StatelessWidget {
     return const FileTranscribeScreen(
       appBarTitle: 'Upload Audio',
       buttonLabel: 'Select Audio',
-      fileTypeGroup: XTypeGroup(label: 'Audio', extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac']),
+      fileTypeGroup: XTypeGroup(
+        label: 'Audio',
+        extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac'],
+      ),
     );
   }
 }

--- a/frontend/learns/lib/screens/file_transcribe_screen.dart
+++ b/frontend/learns/lib/screens/file_transcribe_screen.dart
@@ -21,32 +21,33 @@ class FileTranscribeScreen extends StatefulWidget {
 
 class _FileTranscribeScreenState extends State<FileTranscribeScreen> {
   File? _picked;
-  String? _transcript;
+  String? _result;
   bool _busy = false;
-
   final _svc = TranscriptionService();
 
   Future<void> _pick() async {
-    final xFile = await openFile(acceptedTypeGroups: [widget.fileTypeGroup]);
-    if (xFile == null) return;
+    final x = await openFile(acceptedTypeGroups: [widget.fileTypeGroup]);
+    if (x == null) return;
     setState(() {
-      _picked = File(xFile.path);
-      _transcript = null;
+      _picked = File(x.path);
+      _result = null;
     });
   }
 
   Future<void> _run() async {
-    if (_picked == null) return;
+    final f = _picked;
+    if (f == null) return;
     setState(() => _busy = true);
-    final text = await _svc.transcribeFile(_picked!);
+    final out = await _svc.sendFile(f);
     setState(() {
-      _transcript = text;
+      _result = out;
       _busy = false;
     });
   }
 
   @override
   Widget build(BuildContext context) {
+    final isErr = (_result ?? '').startsWith('Error:');
     return Scaffold(
       appBar: AppBar(title: Text(widget.appBarTitle)),
       body: Padding(
@@ -58,10 +59,14 @@ class _FileTranscribeScreenState extends State<FileTranscribeScreen> {
             Text(_picked!.path, style: const TextStyle(fontSize: 12, color: Colors.white70)),
             const SizedBox(height: 16),
           ],
-          if (_transcript != null) ...[
-            const Text('Transcript:', style: TextStyle(fontWeight: FontWeight.bold)),
+          if (_result != null) ...[
+            const Text('Result:', style: TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            Expanded(child: SingleChildScrollView(child: Text(_transcript!))),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Text(_result!, style: TextStyle(color: isErr ? Colors.red : null)),
+              ),
+            ),
             const SizedBox(height: 16),
           ] else
             const Spacer(),

--- a/frontend/learns/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learns/lib/screens/pdf_picker_screen.dart
@@ -1,105 +1,19 @@
-import 'dart:io';
-
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:syncfusion_flutter_pdf/pdf.dart';
+import 'file_transcribe_screen.dart';
 
-import '../widgets/primary_button.dart';
-import '../constants.dart';
-import '../content_provider.dart';
-
-/// Allows the user to pick a PDF file and extract its text locally.
-class PdfPickerScreen extends StatefulWidget {
+class PdfPickerScreen extends StatelessWidget {
   const PdfPickerScreen({super.key});
 
   @override
-  State<PdfPickerScreen> createState() => _PdfPickerScreenState();
-}
-
-class _PdfPickerScreenState extends State<PdfPickerScreen> {
-  File? _file;
-  String? _text;
-  bool _isProcessing = false;
-
-  Future<void> _pickPdf() async {
-    final XFile? result = await openFile(
-      acceptedTypeGroups: [
-        XTypeGroup(label: 'pdf', extensions: ['pdf']),
-      ],
-    );
-    if (!mounted) return;
-    if (result == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('No file selected')),
-      );
-      return;
-    }
-
-    _file = File(result.path);
-    setState(() {
-      _isProcessing = true;
-      _text = null;
-    });
-
-    try {
-      final document = PdfDocument(
-        inputBytes: await File(_file!.path).readAsBytes(),
-      );
-      final text = PdfTextExtractor(document).extractText();
-      document.dispose();
-      if (!mounted) return;
-      context.read<ContentProvider>().setFileContent(
-        path: _file!.path,
-        content: text,
-      );
-      setState(() {
-        _text = text;
-        _isProcessing = false;
-      });
-    } catch (e) {
-      _showError('Failed to process PDF');
-      if (mounted) setState(() => _isProcessing = false);
-    }
-  }
-
-  void _continue() {
-    Navigator.pushNamed(context, Routes.loading);
-  }
-
-  void _showError(String message) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
-    );
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Upload PDF')),
-      body: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            PrimaryButton(
-              label: 'Choose PDF',
-              onPressed: _isProcessing ? null : _pickPdf,
-            ),
-            const SizedBox(height: 16),
-            PrimaryButton(
-              label: 'Continue',
-              onPressed: (_text != null && !_isProcessing) ? _continue : null,
-            ),
-            if (_isProcessing) ...[
-              const SizedBox(height: 20),
-              const CircularProgressIndicator(),
-            ],
-          ],
-        ),
+    return const FileTranscribeScreen(
+      appBarTitle: 'Upload Document',
+      buttonLabel: 'Select PDF',
+      fileTypeGroup: XTypeGroup(
+        label: 'PDF',
+        extensions: ['pdf'],
       ),
     );
   }
 }
-

--- a/frontend/learns/lib/screens/video_picker_screen.dart
+++ b/frontend/learns/lib/screens/video_picker_screen.dart
@@ -10,7 +10,10 @@ class VideoPickerScreen extends StatelessWidget {
     return const FileTranscribeScreen(
       appBarTitle: 'Upload Video',
       buttonLabel: 'Choose Video',
-      fileTypeGroup: XTypeGroup(label: 'Video', extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm']),
+      fileTypeGroup: XTypeGroup(
+        label: 'Video',
+        extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm'],
+      ),
     );
   }
 }

--- a/frontend/learns/lib/services/transcription_service.dart
+++ b/frontend/learns/lib/services/transcription_service.dart
@@ -1,66 +1,30 @@
 import 'dart:convert';
 import 'dart:io';
-
-import 'package:ffmpeg_kit_flutter_new/ffmpeg_kit.dart';
-import 'package:ffmpeg_kit_flutter_new/return_code.dart';
-import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 class TranscriptionService {
-  // Android emulator: 10.0.2.2 points to the host machine
-  final Uri _endpoint = Uri.parse('http://10.0.2.2:8000/transcribe');
+  // Android emulator host:
+  final Uri _endpoint = Uri.parse('http://10.0.2.2:8000/upload-content');
 
-  Future<String> transcribeFile(File input) async {
-    File? tmpWav;
+  Future<String> sendFile(File f) async {
     try {
-      // 1) Convert to WAV 16kHz mono (strip video track if any)
-      final tmpDir = await getTemporaryDirectory();
-      final outPath = p.join(
-        tmpDir.path,
-        '${p.basenameWithoutExtension(input.path)}_${DateTime.now().millisecondsSinceEpoch}.wav',
-      );
-      tmpWav = File(outPath);
-
-      final ext = p.extension(input.path).toLowerCase();
-      final isVideo = ['.mp4', '.mkv', '.mov', '.avi', '.webm'].contains(ext);
-
-      final cmd = isVideo
-          ? '-i "${input.path}" -vn -ac 1 -ar 16000 -sample_fmt s16 -f wav "$outPath"'
-          : '-i "${input.path}" -ac 1 -ar 16000 -sample_fmt s16 -f wav "$outPath"';
-
-      final session = await FFmpegKit.execute(cmd);
-      final rc = await session.getReturnCode();
-      if (rc == null || !ReturnCode.isSuccess(rc)) {
-        final logs = await session.getAllLogsAsString();
-        throw 'FFmpeg failed (rc=$rc). $logs';
-      }
-      if (!await tmpWav.exists()) throw 'WAV not created';
-
-      // 2) Upload to backend
       final req = http.MultipartRequest('POST', _endpoint)
-        ..files.add(await http.MultipartFile.fromPath('file', tmpWav.path));
+        ..files.add(await http.MultipartFile.fromPath('file', f.path));
+      final res = await req.send().timeout(const Duration(minutes: 2));
+      final body = await res.stream.bytesToString();
 
-      final streamed = await req.send().timeout(const Duration(minutes: 2));
-      final body = await streamed.stream.bytesToString();
-
-      if (streamed.statusCode != 200) {
-        throw 'HTTP ${streamed.statusCode}: $body';
+      if (res.statusCode != 200) {
+        return 'Error: HTTP ${res.statusCode}: $body';
       }
 
-      // 3) Parse transcript
       final map = jsonDecode(body) as Map<String, dynamic>;
-      final text = (map['text'] ?? map['transcript'] ?? map['result'] ?? '').toString();
-      if (text.trim().isEmpty) throw 'Empty transcript';
-      return text;
-    } catch (e, st) {
-      debugPrint('TranscriptionService error: $e\n$st');
+      final txt = (map['text'] ?? '').toString();
+      if (txt.trim().isNotEmpty) return txt;
+
+      // For non-audio/video responses (e.g., course JSON), return raw JSON text
+      return jsonEncode(map);
+    } catch (e) {
       return 'Error: $e';
-    } finally {
-      if (tmpWav != null && await tmpWav.exists()) {
-        await tmpWav.delete();
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Send files directly from Flutter without local transcoding
- Consolidate audio/video/pdf pickers through a reusable file transcribe screen
- Accept uploads on backend by MIME or extension and raise size limit

## Testing
- `dart format frontend/learns/lib/services/transcription_service.dart frontend/learns/lib/screens/file_transcribe_screen.dart frontend/learns/lib/screens/audio_picker_screen.dart frontend/learns/lib/screens/video_picker_screen.dart frontend/learns/lib/screens/pdf_picker_screen.dart` *(command not found)*
- `flutter analyze frontend/learns` *(command not found)*
- `python -m black backend/main.py --check` *(would reformat backend/main.py)*
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68a6963afb9c8329be7fa6b4401e52aa