### PR TITLE
feat: centralize media upload size limit

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -7,3 +7,5 @@ services:
     command: uvicorn main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
+    environment:
+      - MAX_MEDIA_BYTES=104857600   # 100 MB

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,8 +30,7 @@ class StudyRequest(BaseModel):
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-MAX_UPLOAD_SIZE = 100 * 1024 * 1024  # 100 MB
+MAX_MEDIA_BYTES = int(os.getenv("MAX_MEDIA_BYTES", str(100 * 1024 * 1024)))  # 100 MB default
 
 app = FastAPI()
 
@@ -43,8 +42,8 @@ async def upload_content(file: UploadFile = File(...)):
         file.file.seek(0, os.SEEK_END)
         size = file.file.tell()
         file.file.seek(0)
-        if size > MAX_UPLOAD_SIZE:
-            raise HTTPException(status_code=400, detail="File too large (max 100MB)")
+        if size > MAX_MEDIA_BYTES:
+            raise HTTPException(status_code=400, detail="File too large")
         content_type = (file.content_type or "").lower()
         ext = os.path.splitext(file.filename or "")[1].lower()
 


### PR DESCRIPTION
## Summary
- make media upload limit configurable via `MAX_MEDIA_BYTES`
- apply unified size check across audio, video, and document processing
- expose `MAX_MEDIA_BYTES` env in docker-compose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6daf4b2c88329b4e3172b49d8009a