### PR TITLE
Use OpenAI SDK v1 for transcription

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -9,3 +9,4 @@ services:
       - "8000:8000"
     environment:
       - MAX_MEDIA_BYTES=104857600   # 100 MB
+      - OPENAI_TRANSCRIBE_MODEL=whisper-1


### PR DESCRIPTION
## Summary
- refactor generator transcription to use `OpenAI` client with new `audio.transcriptions` API
- add env vars and size checks for media uploads
- expose `OPENAI_TRANSCRIBE_MODEL` and `MAX_MEDIA_BYTES` in docker compose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6deb853b0832995df99f9e502bcc7