### PR TITLE
Add study pack analysis flow to Flutter client

### DIFF
--- a/frontend/learns/lib/screens/analysis_screen.dart
+++ b/frontend/learns/lib/screens/analysis_screen.dart
@@ -1,52 +1,76 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../widgets/primary_button.dart';
-import '../constants.dart';
 import '../content_provider.dart';
 
-/// Presents the processed text to the user and allows them to choose
-/// their preferred study method. The text is scrollable and uses
-/// the current theme’s text styles.
 class AnalysisScreen extends StatelessWidget {
   const AnalysisScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
-    final summary = provider.summary ?? 'Summary will appear here.';
-    final topics = provider.topics.isNotEmpty
-        ? provider.topics.join(', ')
-        : 'Topics will appear here.';
+    final p = context.watch<ContentProvider>();
+    final data = p.analysis ?? {};
+
+    final summary = data['summary'] as String? ?? '';
+    final flashcards = (data['flashcards'] as List?) ?? const [];
+    final quiz = (data['quiz'] as List?) ?? const [];
+    final conceptMap = (data['concept_map'] as List?) ?? const [];
+    final spaced = (data['spaced_repetition'] as List?) ?? const [];
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Analysis')),
-      body: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: Column(
-          children: [
-            Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      summary,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.white70),
-                      textAlign: TextAlign.justify,
-                    ),
-                    const SizedBox(height: 12),
-                    Text('Topics: $topics'),
-                  ],
+      appBar: AppBar(title: const Text('Study Pack')),
+      body: p.loading
+          ? const Center(child: CircularProgressIndicator())
+          : p.error != null
+              ? Center(child: Text('Error: ${p.error}'))
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (summary.isNotEmpty) ...[
+                        const Text('Summary', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        Text(summary),
+                        const SizedBox(height: 16),
+                      ],
+                      if (flashcards.isNotEmpty) ...[
+                        const Text('Flashcards', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        for (final fc in flashcards)
+                          Card(
+                            child: ListTile(
+                              title: Text(fc['term']?.toString() ?? ''),
+                              subtitle: Text(fc['definition']?.toString() ?? ''),
+                            ),
+                          ),
+                        const SizedBox(height: 16),
+                      ],
+                      if (quiz.isNotEmpty) ...[
+                        const Text('Quiz', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        for (final q in quiz)
+                          Card(
+                            child: ListTile(
+                              title: Text(q['question']?.toString() ?? ''),
+                              subtitle: Text((q['options'] as List?)?.join(' · ') ?? ''),
+                            ),
+                          ),
+                        const SizedBox(height: 16),
+                      ],
+                      if (conceptMap.isNotEmpty) ...[
+                        const Text('Concept Map', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        Text(conceptMap.join(' → ')),
+                        const SizedBox(height: 16),
+                      ],
+                      if (spaced.isNotEmpty) ...[
+                        const Text('Spaced Repetition', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        for (final s in spaced) Text('• ${s.toString()}'),
+                      ],
+                    ],
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            PrimaryButton(
-              label: 'Choose Study Mode',
-              onPressed: () => Navigator.pushNamed(context, Routes.methodSelection),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/frontend/learns/lib/screens/audio_picker_screen.dart
+++ b/frontend/learns/lib/screens/audio_picker_screen.dart
@@ -14,6 +14,7 @@ class AudioPickerScreen extends StatelessWidget {
         label: 'Audio',
         extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac'],
       ),
+      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/screens/video_picker_screen.dart
+++ b/frontend/learns/lib/screens/video_picker_screen.dart
@@ -14,6 +14,7 @@ class VideoPickerScreen extends StatelessWidget {
         label: 'Video',
         extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm'],
       ),
+      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/services/transcription_service.dart
+++ b/frontend/learns/lib/services/transcription_service.dart
@@ -27,4 +27,20 @@ class TranscriptionService {
       return 'Error: $e';
     }
   }
+
+  // Calls the backend to analyze a block of [text] and returns the parsed JSON
+  // response. Throws an [Exception] if the request fails.
+  Future<Map<String, dynamic>> analyzeText(String text,
+      {String mode = 'memorization'}) async {
+    final uri = Uri.parse('http://10.0.2.2:8000/analyze');
+    final resp = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'text': text, 'mode': mode}),
+    );
+    if (resp.statusCode != 200) {
+      throw Exception('Analyze failed (${resp.statusCode}): ${resp.body}');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
 }


### PR DESCRIPTION
## Summary
- call new `/analyze` endpoint via `TranscriptionService`
- centralize transcript and study pack state in `ContentProvider`
- show generated summary, flashcards, quiz etc. in `AnalysisScreen`
- add "Generate Study Pack" action after audio/video transcription

## Testing
- `dart format lib/services/transcription_service.dart lib/content_provider.dart lib/screens/analysis_screen.dart lib/screens/file_transcribe_screen.dart lib/screens/audio_picker_screen.dart lib/screens/video_picker_screen.dart` *(fails: command not found)*
- `flutter format lib/services/transcription_service.dart lib/content_provider.dart lib/screens/analysis_screen.dart lib/screens/file_transcribe_screen.dart lib/screens/audio_picker_screen.dart lib/screens/video_picker_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7799797808329820a1649b011a1d8