### PR TITLE
Improve study pack analysis and UI buttons

### DIFF
--- a/frontend/learns/lib/screens/analysis_screen.dart
+++ b/frontend/learns/lib/screens/analysis_screen.dart
@@ -8,11 +8,12 @@ class AnalysisScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final p = context.watch<ContentProvider>();
-    final data = p.analysis ?? {};
+    final data = p.studyPack ?? {};
 
     final summary = data['summary'] as String? ?? '';
-    final flashcards = (data['flashcards'] as List?) ?? const [];
-    final quiz = (data['quiz'] as List?) ?? const [];
+    final flashcards =
+        (data['flashcards'] as List?)?.cast<Map<String, dynamic>>() ?? [];
+    final quiz = (data['quiz'] as List?)?.cast<Map<String, dynamic>>() ?? [];
     final conceptMap = (data['concept_map'] as List?) ?? const [];
     final spaced = (data['spaced_repetition'] as List?) ?? const [];
 

--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../widgets/primary_button.dart';
+import '../widgets/wide_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 import '../widgets/key_value_card.dart';
@@ -35,7 +35,7 @@ class ContextualAssociationScreen extends StatelessWidget {
             else
               const Center(child: Text('No exercises generated.')),
             const SizedBox(height: 16),
-            PrimaryButton(
+            WideButton(
               label: 'Complete Session',
               onPressed: () =>
                   Navigator.pushNamed(context, Routes.progress),

--- a/frontend/learns/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learns/lib/screens/deep_understanding_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../widgets/primary_button.dart';
+import '../widgets/wide_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 import '../widgets/key_value_card.dart';
@@ -42,7 +42,7 @@ class DeepUnderstandingScreen extends StatelessWidget {
             else
               const Center(child: Text('No concept map available.')),
             const SizedBox(height: 16),
-            PrimaryButton(
+            WideButton(
               label: 'Complete Session',
               onPressed: () => Navigator.pushNamed(context, Routes.progress),
             ),

--- a/frontend/learns/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learns/lib/screens/interactive_evaluation_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../widgets/quiz_question_card.dart';
-import '../widgets/primary_button.dart';
+import '../widgets/wide_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 import '../widgets/key_value_card.dart';
@@ -44,7 +44,7 @@ class InteractiveEvaluationScreen extends StatelessWidget {
             else
               const Center(child: Text('No questions generated.')),
             const SizedBox(height: 16),
-            PrimaryButton(
+            WideButton(
               label: 'Submit',
               onPressed: () {
                 ScaffoldMessenger.of(context).showSnackBar(
@@ -53,7 +53,7 @@ class InteractiveEvaluationScreen extends StatelessWidget {
               },
             ),
             const SizedBox(height: 16),
-            PrimaryButton(
+            WideButton(
               label: 'Complete Session',
               onPressed: () =>
                   Navigator.pushNamed(context, Routes.progress),

--- a/frontend/learns/lib/screens/memorization_screen.dart
+++ b/frontend/learns/lib/screens/memorization_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../widgets/flashcard_widget.dart';
-import '../widgets/primary_button.dart';
+import '../widgets/wide_button.dart';
 import '../constants.dart';
 import '../content_provider.dart';
 
@@ -38,7 +38,7 @@ class MemorizationScreen extends StatelessWidget {
             else
               const Text('No flashcards generated'),
             const SizedBox(height: 16),
-            PrimaryButton(
+            WideButton(
               label: 'Complete Session',
               onPressed: () =>
                   Navigator.pushNamed(context, Routes.progress),

--- a/frontend/learns/lib/screens/text_input_screen.dart
+++ b/frontend/learns/lib/screens/text_input_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
-import '../widgets/primary_button.dart';
+import '../widgets/wide_button.dart';
 import '../theme/app_theme.dart';
 import '../constants.dart';
 import '../content_provider.dart';
@@ -67,7 +67,7 @@ class _TextInputScreenState extends State<TextInputScreen> {
               ),
             ),
             const SizedBox(height: 16),
-            PrimaryButton(label: 'Continue', onPressed: _onContinuePressed),
+            WideButton(label: 'Continue', onPressed: _onContinuePressed),
           ],
         ),
       ),

--- a/frontend/learns/lib/theme/app_theme.dart
+++ b/frontend/learns/lib/theme/app_theme.dart
@@ -18,6 +18,14 @@ class AppTheme {
       colorScheme: const ColorScheme.dark(
         primary: accentTeal,
       ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size.fromHeight(52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+      ),
       appBarTheme: const AppBarTheme(
         backgroundColor: background,
         elevation: 0,

--- a/frontend/learns/lib/widgets/wide_button.dart
+++ b/frontend/learns/lib/widgets/wide_button.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class WideButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final bool primary;
+
+  const WideButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.primary = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final background = primary ? scheme.primary : scheme.surfaceVariant;
+    final foreground =
+        primary ? scheme.onPrimary : scheme.onSurfaceVariant;
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: background,
+          foregroundColor: foreground,
+          minimumSize: const Size.fromHeight(52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+        onPressed: onPressed,
+        child: Text(
+          label,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Normalize analysis API responses and cache study packs
- Introduce full-width WideButton and update screens to use it
- Improve transcription flow to run analysis before navigating

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, cannot install Flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a780d4856083299ed0aec70d217d71