### PR TITLE
Handle flexible analysis responses and safer study flow

### DIFF
--- a/frontend/learns/lib/screens/analysis_screen.dart
+++ b/frontend/learns/lib/screens/analysis_screen.dart
@@ -7,71 +7,61 @@ class AnalysisScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final p = context.watch<ContentProvider>();
-    final data = p.studyPack ?? {};
+    return Consumer<ContentProvider>(
+      builder: (context, p, _) {
+        return Scaffold(
+          appBar: AppBar(title: const Text('Study Pack')),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: () {
+              if (p.analyzing) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (p.error != null) {
+                return Text(p.error!, style: const TextStyle(color: Colors.red));
+              }
+              final pack = p.studyPack;
+              if (pack == null) {
+                return const Text('No analysis yet. Transcribe and continue to generate the pack.');
+              }
 
-    final summary = data['summary'] as String? ?? '';
-    final flashcards =
-        (data['flashcards'] as List?)?.cast<Map<String, dynamic>>() ?? [];
-    final quiz = (data['quiz'] as List?)?.cast<Map<String, dynamic>>() ?? [];
-    final conceptMap = (data['concept_map'] as List?) ?? const [];
-    final spaced = (data['spaced_repetition'] as List?) ?? const [];
+              final summary = (pack['summary'] ?? '').toString();
+              final items = (pack['items'] is List) ? (pack['items'] as List) : const [];
+              final flash =
+                  (pack['flashcards'] is List) ? (pack['flashcards'] as List) : const [];
+              final quiz = (pack['quiz'] is List) ? (pack['quiz'] as List) : const [];
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Study Pack')),
-      body: p.loading
-          ? const Center(child: CircularProgressIndicator())
-          : p.error != null
-              ? Center(child: Text('Error: ${p.error}'))
-              : SingleChildScrollView(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (summary.isNotEmpty) ...[
-                        const Text('Summary', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        Text(summary),
-                        const SizedBox(height: 16),
-                      ],
-                      if (flashcards.isNotEmpty) ...[
-                        const Text('Flashcards', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final fc in flashcards)
-                          Card(
-                            child: ListTile(
-                              title: Text(fc['term']?.toString() ?? ''),
-                              subtitle: Text(fc['definition']?.toString() ?? ''),
-                            ),
-                          ),
-                        const SizedBox(height: 16),
-                      ],
-                      if (quiz.isNotEmpty) ...[
-                        const Text('Quiz', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final q in quiz)
-                          Card(
-                            child: ListTile(
-                              title: Text(q['question']?.toString() ?? ''),
-                              subtitle: Text((q['options'] as List?)?.join(' · ') ?? ''),
-                            ),
-                          ),
-                        const SizedBox(height: 16),
-                      ],
-                      if (conceptMap.isNotEmpty) ...[
-                        const Text('Concept Map', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        Text(conceptMap.join(' → ')),
-                        const SizedBox(height: 16),
-                      ],
-                      if (spaced.isNotEmpty) ...[
-                        const Text('Spaced Repetition', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final s in spaced) Text('• ${s.toString()}'),
-                      ],
-                    ],
-                  ),
-                ),
+              return ListView(
+                children: [
+                  if (summary.isNotEmpty) ...[
+                    const Text('Summary', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    Text(summary),
+                    const SizedBox(height: 16),
+                  ],
+                  if (items.isNotEmpty) ...[
+                    const Text('Items', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...items.map((e) => Text(e.toString())),
+                    const SizedBox(height: 16),
+                  ],
+                  if (flash.isNotEmpty) ...[
+                    const Text('Flashcards', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...flash.map((e) => Text(e.toString())),
+                    const SizedBox(height: 16),
+                  ],
+                  if (quiz.isNotEmpty) ...[
+                    const Text('Quiz', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...quiz.map((e) => Text(e.toString())),
+                  ],
+                ],
+              );
+            }(),
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/learns/lib/screens/audio_picker_screen.dart
+++ b/frontend/learns/lib/screens/audio_picker_screen.dart
@@ -10,11 +10,10 @@ class AudioPickerScreen extends StatelessWidget {
     return const FileTranscribeScreen(
       appBarTitle: 'Upload Audio',
       buttonLabel: 'Select Audio',
-      fileTypeGroup: XTypeGroup(
+      typeGroup: XTypeGroup(
         label: 'Audio',
         extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac'],
       ),
-      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learns/lib/screens/deep_understanding_screen.dart
@@ -9,7 +9,6 @@ import '../widgets/key_value_card.dart';
 /// Provides a deep understanding session. Users can listen to an
 /// audio explanation and view a concept map. Upon completion, they
 /// navigate to the progress screen using a named route (not
-
 /// replacement) to preserve navigation history.
 class DeepUnderstandingScreen extends StatelessWidget {
   const DeepUnderstandingScreen({super.key});
@@ -17,8 +16,8 @@ class DeepUnderstandingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<ContentProvider>();
-    final conceptMap = provider.conceptMap;
-    final links = (conceptMap?['links'] as List?);
+    final pack = provider.studyPack;
+    final links = pack == null ? const [] : provider.safeList(pack, 'concept_map');
 
     return Scaffold(
       appBar: AppBar(title: const Text('Deep Understanding')),
@@ -27,15 +26,14 @@ class DeepUnderstandingScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (links != null && links.isNotEmpty)
+            if (links.isNotEmpty)
               Expanded(
                 child: ListView.separated(
                   itemCount: links.length,
-                  separatorBuilder: (context, index) =>
-                      const SizedBox(height: 16),
+                  separatorBuilder: (context, index) => const SizedBox(height: 16),
                   itemBuilder: (context, index) {
-                    final link = links[index] as Map<String, dynamic>;
-                    return KeyValueCard(data: link);
+                    final link = (links[index] as Map?) ?? {};
+                    return KeyValueCard(data: Map<String, dynamic>.from(link));
                   },
                 ),
               )
@@ -52,4 +50,3 @@ class DeepUnderstandingScreen extends StatelessWidget {
     );
   }
 }
-

--- a/frontend/learns/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learns/lib/screens/interactive_evaluation_screen.dart
@@ -15,8 +15,8 @@ class InteractiveEvaluationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final exercises =
-        context.watch<ContentProvider>().evaluationQuestions;
+    final p = context.watch<ContentProvider>();
+    final exercises = p.studyPack == null ? const [] : p.safeList(p.studyPack!, 'quiz');
     return Scaffold(
       appBar: AppBar(title: const Text('Interactive Evaluation')),
       body: Padding(
@@ -29,15 +29,15 @@ class InteractiveEvaluationScreen extends StatelessWidget {
                   itemCount: exercises.length,
                   separatorBuilder: (_, __) => const SizedBox(height: 16),
                   itemBuilder: (context, index) {
-                    final ex = exercises[index];
+                    final ex = (exercises[index] as Map?) ?? {};
                     if (ex.containsKey('choices')) {
                       return QuizQuestionCard(
-                        question: ex['question'] ?? '',
+                        question: ex['question']?.toString() ?? '',
                         choices: List<String>.from(ex['choices'] ?? const []),
                         correctIndex: ex['correctIndex'] as int? ?? 0,
                       );
                     }
-                    return KeyValueCard(data: ex);
+                    return KeyValueCard(data: Map<String, dynamic>.from(ex));
                   },
                 ),
               )
@@ -55,8 +55,7 @@ class InteractiveEvaluationScreen extends StatelessWidget {
             const SizedBox(height: 16),
             WideButton(
               label: 'Complete Session',
-              onPressed: () =>
-                  Navigator.pushNamed(context, Routes.progress),
+              onPressed: () => Navigator.pushNamed(context, Routes.progress),
             ),
           ],
         ),
@@ -64,4 +63,3 @@ class InteractiveEvaluationScreen extends StatelessWidget {
     );
   }
 }
-

--- a/frontend/learns/lib/screens/memorization_screen.dart
+++ b/frontend/learns/lib/screens/memorization_screen.dart
@@ -14,7 +14,8 @@ class MemorizationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cards = context.watch<ContentProvider>().flashcards;
+    final p = context.watch<ContentProvider>();
+    final cards = p.studyPack == null ? const [] : p.safeList(p.studyPack!, 'flashcards');
     return Scaffold(
       appBar: AppBar(title: const Text('Memorization')),
       body: Padding(
@@ -27,10 +28,11 @@ class MemorizationScreen extends StatelessWidget {
                   itemCount: cards.length,
                   separatorBuilder: (_, __) => const SizedBox(height: 16),
                   itemBuilder: (context, index) {
-                    final c = cards[index];
+                    final c = (cards[index] as Map?) ?? {};
                     return FlashcardWidget(
-                      question: c['question'] ?? '',
-                      answer: c['answer'] ?? '',
+                      question: c['question']?.toString() ?? c['term']?.toString() ?? '',
+                      answer:
+                          c['answer']?.toString() ?? c['definition']?.toString() ?? '',
                     );
                   },
                 ),
@@ -40,8 +42,7 @@ class MemorizationScreen extends StatelessWidget {
             const SizedBox(height: 16),
             WideButton(
               label: 'Complete Session',
-              onPressed: () =>
-                  Navigator.pushNamed(context, Routes.progress),
+              onPressed: () => Navigator.pushNamed(context, Routes.progress),
             ),
           ],
         ),
@@ -49,4 +50,3 @@ class MemorizationScreen extends StatelessWidget {
     );
   }
 }
-

--- a/frontend/learns/lib/screens/video_picker_screen.dart
+++ b/frontend/learns/lib/screens/video_picker_screen.dart
@@ -10,11 +10,10 @@ class VideoPickerScreen extends StatelessWidget {
     return const FileTranscribeScreen(
       appBarTitle: 'Upload Video',
       buttonLabel: 'Choose Video',
-      fileTypeGroup: XTypeGroup(
+      typeGroup: XTypeGroup(
         label: 'Video',
         extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm'],
       ),
-      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/widgets/wide_button.dart
+++ b/frontend/learns/lib/widgets/wide_button.dart
@@ -3,37 +3,19 @@ import 'package:flutter/material.dart';
 class WideButton extends StatelessWidget {
   final String label;
   final VoidCallback? onPressed;
-  final bool primary;
-
-  const WideButton({
-    super.key,
-    required this.label,
-    this.onPressed,
-    this.primary = true,
-  });
+  const WideButton({super.key, required this.label, this.onPressed});
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final background = primary ? scheme.primary : scheme.surfaceVariant;
-    final foreground =
-        primary ? scheme.onPrimary : scheme.onSurfaceVariant;
     return SizedBox(
       width: double.infinity,
+      height: 52,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          backgroundColor: background,
-          foregroundColor: foreground,
-          minimumSize: const Size.fromHeight(52),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
         ),
         onPressed: onPressed,
-        child: Text(
-          label,
-          style: const TextStyle(fontWeight: FontWeight.bold),
-        ),
+        child: Text(label),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Simplify ContentProvider into a single transcript source, normalize backend analysis shapes and expose helpers
- Update transcription and analysis screens to use the provider, swap CTA from Transcribe to Continue and prevent double taps
- Render study pack defensively for any backend shape and use wide buttons consistently

## Testing
- ❌ `dart format lib/content_provider.dart lib/screens/file_transcribe_screen.dart lib/screens/analysis_screen.dart lib/screens/audio_picker_screen.dart lib/screens/video_picker_screen.dart lib/screens/memorization_screen.dart lib/screens/deep_understanding_screen.dart lib/screens/interactive_evaluation_screen.dart lib/widgets/wide_button.dart` (command not found)
- ❌ `flutter format lib/content_provider.dart lib/screens/file_transcribe_screen.dart lib/screens/analysis_screen.dart lib/screens/audio_picker_screen.dart lib/screens/video_picker_screen.dart lib/screens/memorization_screen.dart lib/screens/deep_understanding_screen.dart lib/screens/interactive_evaluation_screen.dart lib/widgets/wide_button.dart` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a7870fe7d88329bd35b5ccf20ced6f