### PR TITLE
Refactor analysis flow via provider and resilient UI

### DIFF
--- a/frontend/learns/lib/screens/analysis_screen.dart
+++ b/frontend/learns/lib/screens/analysis_screen.dart
@@ -7,71 +7,61 @@ class AnalysisScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final p = context.watch<ContentProvider>();
-    final data = p.studyPack ?? {};
+    return Consumer<ContentProvider>(
+      builder: (context, p, _) {
+        return Scaffold(
+          appBar: AppBar(title: const Text('Study Pack')),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: () {
+              if (p.analyzing) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (p.error != null) {
+                return Text(p.error!, style: const TextStyle(color: Colors.red));
+              }
+              final pack = p.studyPack;
+              if (pack == null) {
+                return const Text('No analysis yet. Transcribe and continue to generate the pack.');
+              }
 
-    final summary = data['summary'] as String? ?? '';
-    final flashcards =
-        (data['flashcards'] as List?)?.cast<Map<String, dynamic>>() ?? [];
-    final quiz = (data['quiz'] as List?)?.cast<Map<String, dynamic>>() ?? [];
-    final conceptMap = (data['concept_map'] as List?) ?? const [];
-    final spaced = (data['spaced_repetition'] as List?) ?? const [];
+              // Safely read common sections:
+              final summary = (pack['summary'] ?? '').toString();
+              final items   = (pack['items'] is List) ? (pack['items'] as List) : const [];
+              final flash    = (pack['flashcards'] is List) ? (pack['flashcards'] as List) : const [];
+              final quiz     = (pack['quiz'] is List) ? (pack['quiz'] as List) : const [];
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Study Pack')),
-      body: p.loading
-          ? const Center(child: CircularProgressIndicator())
-          : p.error != null
-              ? Center(child: Text('Error: ${p.error}'))
-              : SingleChildScrollView(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (summary.isNotEmpty) ...[
-                        const Text('Summary', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        Text(summary),
-                        const SizedBox(height: 16),
-                      ],
-                      if (flashcards.isNotEmpty) ...[
-                        const Text('Flashcards', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final fc in flashcards)
-                          Card(
-                            child: ListTile(
-                              title: Text(fc['term']?.toString() ?? ''),
-                              subtitle: Text(fc['definition']?.toString() ?? ''),
-                            ),
-                          ),
-                        const SizedBox(height: 16),
-                      ],
-                      if (quiz.isNotEmpty) ...[
-                        const Text('Quiz', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final q in quiz)
-                          Card(
-                            child: ListTile(
-                              title: Text(q['question']?.toString() ?? ''),
-                              subtitle: Text((q['options'] as List?)?.join(' · ') ?? ''),
-                            ),
-                          ),
-                        const SizedBox(height: 16),
-                      ],
-                      if (conceptMap.isNotEmpty) ...[
-                        const Text('Concept Map', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        Text(conceptMap.join(' → ')),
-                        const SizedBox(height: 16),
-                      ],
-                      if (spaced.isNotEmpty) ...[
-                        const Text('Spaced Repetition', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(height: 8),
-                        for (final s in spaced) Text('• ${s.toString()}'),
-                      ],
-                    ],
-                  ),
-                ),
+              return ListView(
+                children: [
+                  if (summary.isNotEmpty) ...[
+                    const Text('Summary', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    Text(summary),
+                    const SizedBox(height: 16),
+                  ],
+                  if (items.isNotEmpty) ...[
+                    const Text('Items', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...items.map((e) => Text(e.toString())),
+                    const SizedBox(height: 16),
+                  ],
+                  if (flash.isNotEmpty) ...[
+                    const Text('Flashcards', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...flash.map((e) => Text(e.toString())),
+                    const SizedBox(height: 16),
+                  ],
+                  if (quiz.isNotEmpty) ...[
+                    const Text('Quiz', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ...quiz.map((e) => Text(e.toString())),
+                  ],
+                ],
+              );
+            }(),
+          ),
+        );
+      },
     );
   }
 }

--- a/frontend/learns/lib/screens/audio_picker_screen.dart
+++ b/frontend/learns/lib/screens/audio_picker_screen.dart
@@ -1,20 +1,49 @@
+import 'dart:io';
+
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/wide_button.dart';
 import 'file_transcribe_screen.dart';
 
 class AudioPickerScreen extends StatelessWidget {
   const AudioPickerScreen({super.key});
 
+  static const XTypeGroup _typeGroup = XTypeGroup(
+    label: 'Audio',
+    extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac'],
+  );
+
+  Future<void> _pick(BuildContext context) async {
+    final x = await openFile(acceptedTypeGroups: [_typeGroup]);
+    if (x == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FileTranscribeScreen(
+          appBarTitle: 'Upload Audio',
+          file: File(x.path),
+          typeGroup: _typeGroup,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const FileTranscribeScreen(
-      appBarTitle: 'Upload Audio',
-      buttonLabel: 'Select Audio',
-      fileTypeGroup: XTypeGroup(
-        label: 'Audio',
-        extensions: ['mp3', 'm4a', 'wav', 'flac', 'ogg', 'aac'],
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload Audio')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Spacer(),
+            WideButton(
+              label: 'Select Audio',
+              onPressed: () => _pick(context),
+            ),
+          ],
+        ),
       ),
-      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -14,7 +14,10 @@ class ContextualAssociationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final exercises = context.watch<ContentProvider>().contextualExercises;
+    final pack = context.watch<ContentProvider>().studyPack;
+    final exercises = (pack?['contextual_association'] is List)
+        ? List<Map<String, dynamic>>.from(pack!['contextual_association'])
+        : const [];
     return Scaffold(
       appBar: AppBar(title: const Text('Contextual Association')),
       body: Padding(

--- a/frontend/learns/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learns/lib/screens/deep_understanding_screen.dart
@@ -16,9 +16,12 @@ class DeepUnderstandingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<ContentProvider>();
-    final conceptMap = provider.conceptMap;
-    final links = (conceptMap?['links'] as List?);
+    final pack = context.watch<ContentProvider>().studyPack;
+    final conceptMap =
+        (pack?['concept_map'] is Map) ? pack!['concept_map'] as Map<String, dynamic> : null;
+    final links = (conceptMap?['links'] is List)
+        ? List<Map<String, dynamic>>.from(conceptMap!['links'])
+        : const [];
 
     return Scaffold(
       appBar: AppBar(title: const Text('Deep Understanding')),
@@ -27,14 +30,14 @@ class DeepUnderstandingScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (links != null && links.isNotEmpty)
+            if (links.isNotEmpty)
               Expanded(
                 child: ListView.separated(
                   itemCount: links.length,
                   separatorBuilder: (context, index) =>
                       const SizedBox(height: 16),
                   itemBuilder: (context, index) {
-                    final link = links[index] as Map<String, dynamic>;
+                    final link = links[index];
                     return KeyValueCard(data: link);
                   },
                 ),

--- a/frontend/learns/lib/screens/interactive_evaluation_screen.dart
+++ b/frontend/learns/lib/screens/interactive_evaluation_screen.dart
@@ -15,8 +15,10 @@ class InteractiveEvaluationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final exercises =
-        context.watch<ContentProvider>().evaluationQuestions;
+    final pack = context.watch<ContentProvider>().studyPack;
+    final exercises = (pack?['quiz'] is List)
+        ? List<Map<String, dynamic>>.from(pack!['quiz'])
+        : const [];
     return Scaffold(
       appBar: AppBar(title: const Text('Interactive Evaluation')),
       body: Padding(

--- a/frontend/learns/lib/screens/memorization_screen.dart
+++ b/frontend/learns/lib/screens/memorization_screen.dart
@@ -14,7 +14,10 @@ class MemorizationScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cards = context.watch<ContentProvider>().flashcards;
+    final pack = context.watch<ContentProvider>().studyPack;
+    final cards = (pack?['flashcards'] is List)
+        ? List<Map<String, dynamic>>.from(pack!['flashcards'])
+        : const [];
     return Scaffold(
       appBar: AppBar(title: const Text('Memorization')),
       body: Padding(
@@ -29,8 +32,8 @@ class MemorizationScreen extends StatelessWidget {
                   itemBuilder: (context, index) {
                     final c = cards[index];
                     return FlashcardWidget(
-                      question: c['question'] ?? '',
-                      answer: c['answer'] ?? '',
+                      question: c['question']?.toString() ?? c['term']?.toString() ?? '',
+                      answer: c['answer']?.toString() ?? c['definition']?.toString() ?? '',
                     );
                   },
                 ),

--- a/frontend/learns/lib/screens/pdf_picker_screen.dart
+++ b/frontend/learns/lib/screens/pdf_picker_screen.dart
@@ -1,18 +1,48 @@
+import 'dart:io';
+
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/wide_button.dart';
 import 'file_transcribe_screen.dart';
 
 class PdfPickerScreen extends StatelessWidget {
   const PdfPickerScreen({super.key});
 
+  static const XTypeGroup _typeGroup = XTypeGroup(
+    label: 'PDF',
+    extensions: ['pdf'],
+  );
+
+  Future<void> _pick(BuildContext context) async {
+    final x = await openFile(acceptedTypeGroups: [_typeGroup]);
+    if (x == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FileTranscribeScreen(
+          appBarTitle: 'Upload Document',
+          file: File(x.path),
+          typeGroup: _typeGroup,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const FileTranscribeScreen(
-      appBarTitle: 'Upload Document',
-      buttonLabel: 'Select PDF',
-      fileTypeGroup: XTypeGroup(
-        label: 'PDF',
-        extensions: ['pdf'],
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload Document')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Spacer(),
+            WideButton(
+              label: 'Select PDF',
+              onPressed: () => _pick(context),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/learns/lib/screens/video_picker_screen.dart
+++ b/frontend/learns/lib/screens/video_picker_screen.dart
@@ -1,20 +1,49 @@
+import 'dart:io';
+
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/wide_button.dart';
 import 'file_transcribe_screen.dart';
 
 class VideoPickerScreen extends StatelessWidget {
   const VideoPickerScreen({super.key});
 
+  static const XTypeGroup _typeGroup = XTypeGroup(
+    label: 'Video',
+    extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm'],
+  );
+
+  Future<void> _pick(BuildContext context) async {
+    final x = await openFile(acceptedTypeGroups: [_typeGroup]);
+    if (x == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FileTranscribeScreen(
+          appBarTitle: 'Upload Video',
+          file: File(x.path),
+          typeGroup: _typeGroup,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const FileTranscribeScreen(
-      appBarTitle: 'Upload Video',
-      buttonLabel: 'Choose Video',
-      fileTypeGroup: XTypeGroup(
-        label: 'Video',
-        extensions: ['mp4', 'mov', 'mkv', 'avi', 'webm'],
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upload Video')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Spacer(),
+            WideButton(
+              label: 'Choose Video',
+              onPressed: () => _pick(context),
+            ),
+          ],
+        ),
       ),
-      enableStudyPack: true,
     );
   }
 }

--- a/frontend/learns/lib/widgets/wide_button.dart
+++ b/frontend/learns/lib/widgets/wide_button.dart
@@ -3,37 +3,19 @@ import 'package:flutter/material.dart';
 class WideButton extends StatelessWidget {
   final String label;
   final VoidCallback? onPressed;
-  final bool primary;
-
-  const WideButton({
-    super.key,
-    required this.label,
-    this.onPressed,
-    this.primary = true,
-  });
+  const WideButton({super.key, required this.label, this.onPressed});
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final background = primary ? scheme.primary : scheme.surfaceVariant;
-    final foreground =
-        primary ? scheme.onPrimary : scheme.onSurfaceVariant;
     return SizedBox(
       width: double.infinity,
+      height: 52,
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
-          backgroundColor: background,
-          foregroundColor: foreground,
-          minimumSize: const Size.fromHeight(52),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
         ),
         onPressed: onPressed,
-        child: Text(
-          label,
-          style: const TextStyle(fontWeight: FontWeight.bold),
-        ),
+        child: Text(label),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Centralize transcript and study pack state in `ContentProvider` with backend analysis and safe parsing
- Streamline file transcription screen to prevent double taps and switch CTA between Transcribe and Continue
- Render analysis results robustly and update study method screens to read from normalized study pack
- Reintroduce consistent wide buttons across picker and study screens

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a788e08c908329a0bd4b70c9d17355