### PR TITLE
Make runAnalysis single-flight

### DIFF
--- a/frontend/learns/lib/screens/file_transcribe_screen.dart
+++ b/frontend/learns/lib/screens/file_transcribe_screen.dart
@@ -59,22 +59,18 @@ class _FileTranscribeScreenState extends State<FileTranscribeScreen> {
 
   Future<void> _continue() async {
     final p = context.read<ContentProvider>();
-    if (p.isAnalyzing) return;
+    if (_busy || p.isAnalyzing) return;
     setState(() => _busy = true);
-    try {
-      if ((_picked?.path ?? '').isNotEmpty && (p.rawText ?? '').isEmpty) {
-        // transcript should already be stored after transcribe
-      }
-      await p.runAnalysis();
-      if (!mounted) return;
-      Navigator.of(context).pushNamed(Routes.studyPack);
-    } catch (e) {
-      if (!mounted) return;
+    final ok = await p.runAnalysis();
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (ok) {
+      Navigator.of(context).pushNamed(Routes.analysis);
+    } else {
+      final msg = p.lastError ?? 'Analysis failed. Please try again.';
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Analysis failed: $e')),
+        SnackBar(content: Text(msg)),
       );
-    } finally {
-      if (mounted) setState(() => _busy = false);
     }
   }
 

--- a/frontend/learns/lib/screens/loading_screen.dart
+++ b/frontend/learns/lib/screens/loading_screen.dart
@@ -22,14 +22,14 @@ class _LoadingScreenState extends State<LoadingScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final p = context.read<ContentProvider>();
-      try {
-        await p.runAnalysis();
-        if (!mounted) return;
-        Navigator.of(context).pushReplacementNamed(Routes.studyPack);
-      } catch (e) {
-        if (!mounted) return;
+      final ok = await p.runAnalysis();
+      if (!mounted) return;
+      if (ok) {
+        Navigator.of(context).pushReplacementNamed(Routes.analysis);
+      } else {
+        final msg = p.lastError ?? 'Analysis failed. Please try again.';
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Analysis failed: $e')),
+          SnackBar(content: Text(msg)),
         );
         // Optionally pop or reset UI here
       }


### PR DESCRIPTION
## Summary
- Refactor ContentProvider.runAnalysis into a single-flight bool-returning call that tracks lastError and canContinue
- Await analysis in file transcription flow, navigating to Routes.analysis on success and surfacing provider errors
- Update loading screen to check runAnalysis result and handle failures gracefully

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a81405cfac8329ac9c88647b2e4e9c