### PR TITLE
Normalize study data for deep and concept modes

### DIFF
--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -11,118 +11,54 @@ class ContextualAssociationScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final p = context.watch<ContentProvider>();
     final groups = p.conceptGroups;
-    final topics = p.conceptTopics;
+    final flat = p.conceptTopics;
 
-    final palette = [
-      Colors.teal,
-      Colors.indigo,
-      Colors.deepOrange,
-      Colors.purple,
-      Colors.blueGrey,
-      Colors.brown,
-      Colors.green,
-      Colors.cyan,
-    ];
-
-    Widget chip(String t, Color c) {
-      return GestureDetector(
-        onLongPress: () {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text(t)));
-        },
-        child: ActionChip(
-          label: Text(
-            t,
-            style: TextStyle(color: c, fontWeight: FontWeight.bold),
-          ),
-          backgroundColor: c.withOpacity(0.2),
+    Widget chip(String t) => ActionChip(
+          label: Text(t),
           onPressed: () {},
-        ),
-      );
-    }
+        );
 
-    if (p.hasConceptGroups) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Concept Map')),
-        body: ListView(
+    Widget buildGroups() => ListView(
           padding: const EdgeInsets.all(16),
-          children: [
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: groups.asMap().entries.map((entry) {
-                final color = palette[entry.key % palette.length];
-                return Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Container(
-                      width: 12,
-                      height: 12,
-                      decoration: BoxDecoration(
-                        color: color,
-                        shape: BoxShape.circle,
+          children: groups
+              .map((g) => ExpansionTile(
+                    title: Text(g.title),
+                    children: [
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: g.topics.map(chip).toList(),
                       ),
-                    ),
-                    const SizedBox(width: 4),
-                    Text(entry.value.title),
-                  ],
-                );
-              }).toList(),
-            ),
-            const SizedBox(height: 12),
-            ...groups.asMap().entries.map((entry) {
-              final idx = entry.key;
-              final group = entry.value;
-              final color = palette[idx % palette.length];
-              return ExpansionTile(
-                title: Text(group.title),
-                initiallyExpanded: true,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children:
-                          group.topics.map((t) => chip(t, color)).toList(),
-                    ),
-                  ),
-                ],
-              );
-            }),
-          ],
-        ),
-      );
-    } else if (topics.isNotEmpty) {
-      final color = palette.first;
-      return Scaffold(
-        appBar: AppBar(title: const Text('Concept Map')),
-        body: ListView(
+                    ],
+                  ))
+              .toList(),
+        );
+
+    Widget buildFlat() => ListView(
           padding: const EdgeInsets.all(16),
           children: [
             ExpansionTile(
-              title: const Text('Topics'),
               initiallyExpanded: true,
+              title: const Text('Topics'),
               children: [
-                Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: topics.map((t) => chip(t, color)).toList(),
-                  ),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: flat.map(chip).toList(),
                 ),
               ],
             ),
           ],
-        ),
-      );
-    } else {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Concept Map')),
-        body: const Center(child: Text('No concept topics available.')),
-      );
-    }
+        );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Concept Map')),
+      body: groups.isNotEmpty
+          ? buildGroups()
+          : flat.isNotEmpty
+              ? buildFlat()
+              : const Center(child: Text('No concept map available')),
+    );
   }
 }
 

--- a/frontend/learns/lib/screens/deep_understanding_screen.dart
+++ b/frontend/learns/lib/screens/deep_understanding_screen.dart
@@ -69,7 +69,7 @@ class _DeepUnderstandingState extends State<DeepUnderstandingScreen> {
               style:
                   const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
             ),
-            if (current.hint != null && current.hint!.isNotEmpty) ...[
+            if (current.hint.isNotEmpty) ...[
               const SizedBox(height: 12),
               TextButton(
                 onPressed: () => setState(() => _showHint = !_showHint),
@@ -79,7 +79,7 @@ class _DeepUnderstandingState extends State<DeepUnderstandingScreen> {
                 Padding(
                   padding: const EdgeInsets.only(top: 4),
                   child: Text(
-                    current.hint!,
+                    current.hint,
                     style: const TextStyle(color: Colors.black54),
                   ),
                 ),
@@ -101,7 +101,7 @@ class _DeepUnderstandingState extends State<DeepUnderstandingScreen> {
                   child: ElevatedButton(
                     onPressed: () {
                       if (last) {
-                        _provider.markDeepDone();
+                        context.read<ContentProvider>().markDeepDone();
                         Navigator.pop(context);
                       } else {
                         _setIndex(_index + 1);

--- a/frontend/learns/lib/screens/method_selection_screen.dart
+++ b/frontend/learns/lib/screens/method_selection_screen.dart
@@ -34,7 +34,7 @@ class _MethodSelectionScreenState extends State<MethodSelectionScreen> {
   @override
   Widget build(BuildContext context) {
     final p = context.watch<ContentProvider>();
-    final canDeep = p.hasDeep;
+    final canDeep = p.canDeep;
     final canConcept = p.canConcept;
 
     return Scaffold(


### PR DESCRIPTION
## Summary
- parse deep prompts and concept map with group/flat fallbacks
- expose capability getters to enable Deep Understanding and Contextual Association buttons
- render concept map groups or a single Topics list
- record Deep Understanding completion on final prompt

## Testing
- `dart format frontend/learns/lib/content_provider.dart frontend/learns/lib/screens/method_selection_screen.dart frontend/learns/lib/screens/contextual_association_screen.dart frontend/learns/lib/screens/deep_understanding_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac0b6c005883299cb1ca2ae50c96ea