### PR TITLE
feat: single-flight analysis

### DIFF
--- a/frontend/learns/lib/screens/analyzing_screen.dart
+++ b/frontend/learns/lib/screens/analyzing_screen.dart
@@ -6,7 +6,6 @@ import '../content_provider.dart';
 
 class AnalyzingScreen extends StatefulWidget {
   const AnalyzingScreen({super.key});
-
   @override
   State<AnalyzingScreen> createState() => _AnalyzingScreenState();
 }
@@ -15,36 +14,34 @@ class _AnalyzingScreenState extends State<AnalyzingScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() =>
-        context.read<ContentProvider>().ensureAnalysisStarted());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+  }
+
+  Future<void> _start() async {
+    final provider = context.read<ContentProvider>();
+    final ok = await provider.runAnalysis();
+    if (!mounted) return;
+
+    if (ok) {
+      Navigator.of(context).pushReplacementNamed(Routes.studyPack);
+    } else {
+      final msg = (provider.lastError?.isNotEmpty ?? false)
+          ? provider.lastError!
+          : 'Analyze failed. Please try again.';
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(msg)));
+      Navigator.of(context).pop();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final p = context.watch<ContentProvider>();
-    final busy = p.isAnalyzing;
-    final canGo = p.canContinue;
-
-    return Scaffold(
-      appBar: AppBar(title: const Text('Analyzing')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            if (busy) const LinearProgressIndicator(),
-            const Spacer(),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: canGo
-                    ? () => Navigator.of(context)
-                        .pushNamed(AppRoutes.studyPack)
-                    : null,
-                child: Text(canGo ? 'Continue' : 'Analyzing...'),
-              ),
-            ),
-          ],
-        ),
+    return const Scaffold(
+      appBar: AppBar(title: Text('Analyzing')),
+      body: Center(child: CircularProgressIndicator()),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.all(16),
+        child: SizedBox(height: 44, child: Center(child: Text('Analyzing...'))),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Implement single-flight `runAnalysis` in `ContentProvider` with robust completion, tolerant JSON parsing, and concept map handling
- Make `AnalyzingScreen` await analysis once and navigate on success or show error

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac1325d5288329826b02007a97dffe