### PR TITLE
fix(concept-map): null-safe mapping of topics

### DIFF
--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -27,7 +27,7 @@ class ContextualAssociationScreen extends StatelessWidget {
                       Wrap(
                         spacing: 8,
                         runSpacing: 8,
-                        children: g.topics.map(chip).toList(),
+                        children: (g.topics?.map<Widget>(chip).toList() ?? const <Widget>[]),
                       ),
                     ],
                   ))


### PR DESCRIPTION
## Summary
- ensure concept map groups handle nullable `topics` safely, returning an empty list when `topics` is null

## Testing
- `dart format frontend/learns/lib/screens/contextual_association_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac18d49bc08329bbc49a2db5ba48c2