### PR TITLE
Expose deep prompts from analyze endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -89,6 +89,8 @@ def analyze_text(text: str = Body(..., embed=True)):
         except Exception:
             data = {"summary": result}
 
+        deep_prompts = make_deep_prompts(text)
+
         return {
             "summary": data.get("summary", ""),
             "concept_map": data.get("concept_map")
@@ -98,6 +100,7 @@ def analyze_text(text: str = Body(..., embed=True)):
             "spaced_repetition": data.get("spaced_repetition")
             or data.get("spacedRepetition", []),
             "progress": data.get("progress", {"completion": 0.0, "masteryLevel": ""}),
+            "deep_prompts": deep_prompts,
         }
     except HTTPException as e:
         raise e

--- a/backend/tests/test_analyze.py
+++ b/backend/tests/test_analyze.py
@@ -109,6 +109,7 @@ def test_analyze_text_schema(monkeypatch):
         "quiz",
         "spaced_repetition",
         "progress",
+        "deep_prompts",
     }
     assert isinstance(result["concept_map"], list)
     assert all({"term", "definition"} <= set(card.keys()) for card in result["flashcards"])
@@ -117,3 +118,4 @@ def test_analyze_text_schema(monkeypatch):
     )
     assert isinstance(result["spaced_repetition"], list)
     assert {"completion", "masteryLevel"} <= set(result["progress"].keys())
+    assert isinstance(result["deep_prompts"], list)


### PR DESCRIPTION
## Summary
- return deep prompts from `/analyze`
- update analysis schema tests for deep prompts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac1cda16f48329884cd62b0e813d55