### PR TITLE
feat(frontend): visualize concept map with graph

### DIFF
--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
 import 'package:provider/provider.dart';
 
 import '../content_provider.dart';
 
-/// Displays concept relationships as groups or chips to help build mental models.
+/// Visualizes concept relationships as an interactive graph to help build mental models.
 class ContextualAssociationScreen extends StatelessWidget {
   const ContextualAssociationScreen({super.key});
 
@@ -13,52 +14,96 @@ class ContextualAssociationScreen extends StatelessWidget {
     final groups = p.conceptGroups;
     final flat = p.conceptTopics;
 
-    Widget chip(String t) => ActionChip(
-          label: Text(t),
-          onPressed: () {},
+    /// Returns a simple node widget with the given [text] and [color].
+    Widget nodeWidget(String text, Color color) => Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: color.withOpacity(0.2),
+            border: Border.all(color: color),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(text),
         );
 
-    Widget buildGroups() => ListView(
-          padding: const EdgeInsets.all(16),
-          children: groups
-              .map((g) => ExpansionTile(
-                    title: Text(g.title),
-                    children: [
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: (g.topics?.map<Widget>(chip).toList() ?? const <Widget>[]),
-                      ),
-                    ],
-                  ))
-              .toList(),
-        );
+    /// Builds the graph using [graphview] based on the available concept data.
+    Widget buildGraph() {
+      final graph = Graph();
+      final Map<String, Node> nodeMap = {};
+      final Map<String, Color> colorMap = {};
 
-    Widget buildFlat() => ListView(
-          padding: const EdgeInsets.all(16),
+      Node getNode(String id) => nodeMap.putIfAbsent(id, () => Node.Id(id));
+
+      if (groups.isNotEmpty) {
+        for (var i = 0; i < groups.length; i++) {
+          final g = groups[i];
+          final groupNode = getNode(g.title);
+          colorMap[g.title] = Colors.grey.shade700;
+          final color = Colors.primaries[i % Colors.primaries.length];
+          for (final topic in g.topics ?? []) {
+            final topicNode = getNode(topic);
+            colorMap[topic] = color;
+            graph.addEdge(groupNode, topicNode);
+          }
+        }
+      } else if (flat.isNotEmpty) {
+        final root = getNode('Topics');
+        colorMap['Topics'] = Colors.grey.shade700;
+        for (var i = 0; i < flat.length; i++) {
+          final topic = flat[i];
+          final node = getNode(topic);
+          colorMap[topic] = Colors.primaries[i % Colors.primaries.length];
+          graph.addEdge(root, node);
+        }
+      }
+
+      final builder = FruchtermanReingoldAlgorithm();
+      return InteractiveViewer(
+        constrained: false,
+        boundaryMargin: const EdgeInsets.all(100),
+        minScale: 0.01,
+        maxScale: 5,
+        child: GraphView(
+          graph: graph,
+          algorithm: builder,
+          builder: (Node node) {
+            final id = node.key!.value as String;
+            return nodeWidget(id, colorMap[id] ?? Colors.blue);
+          },
+        ),
+      );
+    }
+
+    /// Renders a simple legend mapping each group to its color.
+    Widget legend() {
+      if (groups.isEmpty) return const SizedBox.shrink();
+      return Padding(
+        padding: const EdgeInsets.all(8),
+        child: Wrap(
+          spacing: 8,
           children: [
-            ExpansionTile(
-              initiallyExpanded: true,
-              title: const Text('Topics'),
-              children: [
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: flat.map(chip).toList(),
-                ),
-              ],
-            ),
+            for (var i = 0; i < groups.length; i++)
+              Chip(
+                label: Text(groups[i].title),
+                backgroundColor:
+                    Colors.primaries[i % Colors.primaries.length].withOpacity(0.3),
+              ),
           ],
-        );
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('Concept Map')),
-      body: groups.isNotEmpty
-          ? buildGroups()
-          : flat.isNotEmpty
-              ? buildFlat()
-              : const Center(child: Text('No concept map available')),
+      body: groups.isEmpty && flat.isEmpty
+          ? const Center(child: Text('No concept map available'))
+          : Column(
+              children: [
+                Expanded(child: buildGraph()),
+                legend(),
+              ],
+            ),
     );
   }
 }
+
 

--- a/frontend/learns/pubspec.yaml
+++ b/frontend/learns/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   path_provider: ^2.1.3
   path: ^1.9.0
+  graphview: ^1.3.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add graphview dependency for graph visualization
- render concept groups/topics as interactive graph with legend and zoom support

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ebc3ed48329a3b98f80449bb7d6