### PR TITLE
feat: visualize grouped concept maps

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -74,7 +74,7 @@ def analyze_text(text: str = Body(..., embed=True)):
         "Analyze the following text and respond only in JSON with the keys:\n"
         "{\n"
         '  "summary": str,\n'
-        '  "concept_map": [str, ...],\n'
+        '  "concept_map": {"groups": [{"title": str, "topics": [str, ...]}]},\n'
         '  "flashcards": [{"term": str, "definition": str}],\n'
         '  "quiz": [{"question": str, "options": [str, ...], "answer": str}],\n'
         '  "spaced_repetition": [str, ...],\n'
@@ -94,7 +94,7 @@ def analyze_text(text: str = Body(..., embed=True)):
         return {
             "summary": data.get("summary", ""),
             "concept_map": data.get("concept_map")
-            or data.get("conceptMap", []),
+            or data.get("conceptMap", {"groups": []}),
             "flashcards": data.get("flashcards", []),
             "quiz": data.get("quiz") or data.get("quizQuestions", []),
             "spaced_repetition": data.get("spaced_repetition")

--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -36,9 +36,10 @@ class ContextualAssociationScreen extends StatelessWidget {
       if (groups.isNotEmpty) {
         for (var i = 0; i < groups.length; i++) {
           final g = groups[i];
+          final color =
+              Colors.primaries[(i + 1) % Colors.primaries.length];
           final groupNode = getNode(g.title);
-          colorMap[g.title] = Colors.grey.shade700;
-          final color = Colors.primaries[i % Colors.primaries.length];
+          colorMap[g.title] = color;
           for (final topic in g.topics ?? []) {
             final topicNode = getNode(topic);
             colorMap[topic] = color;
@@ -51,12 +52,19 @@ class ContextualAssociationScreen extends StatelessWidget {
         for (var i = 0; i < flat.length; i++) {
           final topic = flat[i];
           final node = getNode(topic);
-          colorMap[topic] = Colors.primaries[i % Colors.primaries.length];
+          colorMap[topic] =
+              Colors.primaries[(i + 1) % Colors.primaries.length];
           graph.addEdge(root, node);
         }
       }
 
-      final builder = FruchtermanReingoldAlgorithm();
+      final builder = BuchheimWalkerAlgorithm(
+        BuchheimWalkerConfiguration()
+          ..siblingSeparation = 20
+          ..levelSeparation = 30
+          ..subtreeSeparation = 20
+          ..orientation = BuchheimWalkerConfiguration.ORIENTATION_TOP_BOTTOM,
+      );
       return InteractiveViewer(
         constrained: false,
         boundaryMargin: const EdgeInsets.all(100),
@@ -84,8 +92,9 @@ class ContextualAssociationScreen extends StatelessWidget {
             for (var i = 0; i < groups.length; i++)
               Chip(
                 label: Text(groups[i].title),
-                backgroundColor:
-                    Colors.primaries[i % Colors.primaries.length].withOpacity(0.3),
+                backgroundColor: Colors
+                    .primaries[(i + 1) % Colors.primaries.length]
+                    .withOpacity(0.3),
               ),
           ],
         ),


### PR DESCRIPTION
## Summary
- request structured concept_map data with grouped topics from backend analysis
- parse grouped concept maps into nodes and relations on the client
- render concept groups with stable Buchheim-Walker layout and distinct colors

## Testing
- `python -m py_compile backend/main.py`
- `pytest backend/tests`
- `dart format frontend/learns/lib/content_provider.dart frontend/learns/lib/screens/contextual_association_screen.dart` *(fails: command not found)*
- `flutter format frontend/learns/lib/content_provider.dart frontend/learns/lib/screens/contextual_association_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac23a885e08329b172249854ed144d