### PR TITLE
Expand vertical spacing in concept map

### DIFF
--- a/frontend/learns/lib/screens/contextual_association_screen.dart
+++ b/frontend/learns/lib/screens/contextual_association_screen.dart
@@ -63,8 +63,8 @@ class ContextualAssociationScreen extends StatelessWidget {
 
       final config = BuchheimWalkerConfiguration()
         ..siblingSeparation = 20
-        ..levelSeparation = 30
-        ..subtreeSeparation = 20
+        ..levelSeparation = 80
+        ..subtreeSeparation = 60
         ..orientation = BuchheimWalkerConfiguration.ORIENTATION_TOP_BOTTOM;
 
       final algorithm = BuchheimWalkerAlgorithm(


### PR DESCRIPTION
## Summary
- Increase `levelSeparation` to 80 and `subtreeSeparation` to 60 in `ContextualAssociationScreen`

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac2b7c625c8329be7b510fe61e0c86